### PR TITLE
avoid redundant memory copy, use io.ReaderFrom, io.WriterTo

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,3 @@
+Dmitri Popov
+Mojo Talantikite
+Giovanni Bajo

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,31 @@
+package tftp
+
+import "time"
+
+const (
+	defaultTimeout = 3 * time.Second
+	defaultRetries = 5
+)
+
+type Retry interface {
+	Reset()
+	Count() int
+	Backoff()
+}
+
+type backoff struct {
+	attempt int
+}
+
+func (b *backoff) Reset() {
+	b.attempt = 0
+}
+
+func (b *backoff) Count() int {
+	return b.attempt
+}
+
+func (b *backoff) Backoff() {
+	time.Sleep(time.Second)
+	b.attempt++
+}

--- a/client.go
+++ b/client.go
@@ -1,111 +1,86 @@
 package tftp
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
-	"sync"
+	"time"
 )
 
-/*
-Client provides TFTP client functionality. It requires remote address and
-optional logger
-
-Uploading file to server example
-
-	addr, e := net.ResolveUDPAddr("udp", "example.org:69")
-	if e != nil {
-		...
+func NewClient(addr string) (*Client, error) {
+	a, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("resolving address %s: %v", addr, err)
 	}
-	file, e := os.Open("/etc/passwd")
-	if e != nil {
-		...
-	}
-	r := bufio.NewReader(file)
-	log := log.New(os.Stderr, "", log.Ldate | log.Ltime)
-	c := tftp.Client{addr, log}
-	c.Put(filename, mode, func(writer *io.PipeWriter) {
-		n, writeError := r.WriteTo(writer)
-		if writeError != nil {
-			fmt.Fprintf(os.Stderr, "Can't put %s: %v\n", filename, writeError);
-		} else {
-			fmt.Fprintf(os.Stderr, "Put %s (%d bytes)\n", filename, n);
-		}
-		writer.Close()
-	})
+	return &Client{
+		addr:    a,
+		retry:   &backoff{},
+		timeout: defaultTimeout,
+	}, nil
+}
 
-Downloading file from server example
+func (c *Client) SetTimeout(t time.Duration) {
+	c.timeout = t
+}
 
-	addr, e := net.ResolveUDPAddr("udp", "example.org:69")
-	if e != nil {
-		...
-	}
-	file, e := os.Create("/var/tmp/debian.img")
-	if e != nil {
-		...
-	}
-	w := bufio.NewWriter(file)
-	log := log.New(os.Stderr, "", log.Ldate | log.Ltime)
-	c := tftp.Client{addr, log}
-	c.Get(filename, mode, func(reader *io.PipeReader) {
-		n, readError := w.ReadFrom(reader)
-		if readError != nil {
-			fmt.Fprintf(os.Stderr, "Can't get %s: %v\n", filename, readError);
-		} else {
-			fmt.Fprintf(os.Stderr, "Got %s (%d bytes)\n", filename, n);
-		}
-		w.Flush()
-		file.Close()
-	})
-*/
 type Client struct {
-	RemoteAddr *net.UDPAddr
-	Log        *log.Logger
+	addr    *net.UDPAddr
+	retry   Retry
+	timeout time.Duration
 }
 
-// Method for uploading file to server
-func (c Client) Put(filename string, mode string, handler func(w *io.PipeWriter)) error {
-	addr, e := net.ResolveUDPAddr("udp", ":0")
-	if e != nil {
-		return e
+func (c Client) Send(filename string, mode string) (io.ReaderFrom, error) {
+	conn, err := transmissionConn()
+	if err != nil {
+		return nil, err
 	}
-	conn, e := net.ListenUDP("udp", addr)
-	if e != nil {
-		return e
+	s := &sender{
+		send:    make([]byte, datagramLength),
+		receive: make([]byte, datagramLength),
+		conn:    conn,
+		retry:   c.retry,
+		timeout: c.timeout,
+		addr:    c.addr,
+		mode:    mode,
 	}
-	reader, writer := io.Pipe()
-	s := &sender{c.RemoteAddr, conn, reader, filename, mode, c.Log}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		handler(writer)
-		wg.Done()
-	}()
-	s.run(false)
-	wg.Wait()
-	return nil
+	n := packRQ(s.send, opWRQ, filename, mode)
+	addr, err := s.sendWithRetry(n)
+	if err != nil {
+		return nil, err // wrap error
+	}
+	s.block++
+	s.addr = addr
+	binary.BigEndian.PutUint16(s.send[0:2], opDATA)
+	return s, nil
 }
 
-// Method for downloading file from server
-func (c Client) Get(filename string, mode string, handler func(r *io.PipeReader)) error {
-	addr, e := net.ResolveUDPAddr("udp", ":0")
-	if e != nil {
-		return e
+func (c Client) Receive(filename string, mode string) (io.WriterTo, error) {
+	conn, err := transmissionConn()
+	if err != nil {
+		return nil, err
 	}
-	conn, e := net.ListenUDP("udp", addr)
-	if e != nil {
-		return e
+	if c.timeout == 0 {
+		c.timeout = defaultTimeout
 	}
-	reader, writer := io.Pipe()
-	r := &receiver{c.RemoteAddr, conn, writer, filename, mode, c.Log}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		handler(reader)
-		wg.Done()
-	}()
-	r.run(false)
-	wg.Wait()
-	return fmt.Errorf("Send timeout")
+	r := &receiver{
+		send:     make([]byte, datagramLength),
+		receive:  make([]byte, datagramLength),
+		conn:     conn,
+		retry:    c.retry,
+		timeout:  c.timeout,
+		addr:     c.addr,
+		autoTerm: true,
+		mode:     mode,
+	}
+	n := packRQ(r.send, opRRQ, filename, mode)
+	r.block++
+	l, addr, err := r.receiveWithRetry(n)
+	if err != nil {
+		return nil, err
+	}
+	r.l = l
+	r.addr = addr
+	binary.BigEndian.PutUint16(r.send[0:2], opACK)
+	return r, nil
 }

--- a/netascii/netascii.go
+++ b/netascii/netascii.go
@@ -1,0 +1,108 @@
+package netascii
+
+// TODO: make it work not only on linux
+
+import "io"
+
+const (
+	CR  = '\x0d'
+	LF  = '\x0a'
+	NUL = '\x00'
+)
+
+func ToReader(r io.Reader) io.Reader {
+	return &toReader{
+		r:   r,
+		buf: make([]byte, 256),
+	}
+}
+
+type toReader struct {
+	r   io.Reader
+	buf []byte
+	n   int
+	i   int
+	err error
+	lf  bool
+	nul bool
+}
+
+func (r *toReader) Read(p []byte) (int, error) {
+	var n int
+	for n < len(p) {
+		if r.lf {
+			p[n] = LF
+			n++
+			r.lf = false
+			continue
+		}
+		if r.nul {
+			p[n] = NUL
+			n++
+			r.nul = false
+			continue
+		}
+		if r.i < r.n {
+			if r.buf[r.i] == LF {
+				p[n] = CR
+				r.lf = true
+			} else if r.buf[r.i] == CR {
+				p[n] = CR
+				r.nul = true
+
+			} else {
+				p[n] = r.buf[r.i]
+			}
+			r.i++
+			n++
+			continue
+		}
+		if r.err == nil {
+			r.n, r.err = r.r.Read(r.buf)
+			r.i = 0
+		} else {
+			return n, r.err
+		}
+	}
+	return n, r.err
+}
+
+type fromWriter struct {
+	w   io.Writer
+	buf []byte
+	i   int
+	cr  bool
+}
+
+func FromWriter(w io.Writer) io.Writer {
+	return &fromWriter{
+		w:   w,
+		buf: make([]byte, 256),
+	}
+}
+
+func (w *fromWriter) Write(p []byte) (n int, err error) {
+	for n < len(p) {
+		if w.cr {
+			if p[n] == LF {
+				w.buf[w.i] = LF
+			}
+			if p[n] == NUL {
+				w.buf[w.i] = CR
+			}
+			w.cr = false
+			w.i++
+		} else if p[n] == CR {
+			w.cr = true
+		} else {
+			w.buf[w.i] = p[n]
+			w.i++
+		}
+		n++
+		if w.i == len(w.buf) || n == len(p) {
+			_, err = w.w.Write(w.buf[:w.i])
+			w.i = 0
+		}
+	}
+	return n, err
+}

--- a/netascii/netascii_test.go
+++ b/netascii/netascii_test.go
@@ -1,0 +1,89 @@
+package netascii
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+var basic = map[string]string{
+	"\r":     "\r\x00",
+	"\n":     "\r\n",
+	"la\nbu": "la\r\nbu",
+	"la\rbu": "la\r\x00bu",
+	"\r\r\r": "\r\x00\r\x00\r\x00",
+	"\n\n\n": "\r\n\r\n\r\n",
+}
+
+func TestTo(t *testing.T) {
+	for text, netascii := range basic {
+		to := ToReader(strings.NewReader(text))
+		n, _ := ioutil.ReadAll(to)
+		if bytes.Compare(n, []byte(netascii)) != 0 {
+			t.Errorf("%q to netascii: %q != %q", text, n, netascii)
+		}
+	}
+}
+
+func TestFrom(t *testing.T) {
+	for text, netascii := range basic {
+		r := bytes.NewReader([]byte(netascii))
+		b := &bytes.Buffer{}
+		from := FromWriter(b)
+		r.WriteTo(from)
+		n, _ := ioutil.ReadAll(b)
+		if string(n) != text {
+			t.Errorf("%q from netascii: %q != %q", netascii, n, text)
+		}
+	}
+}
+
+const text = `
+Therefore, the sequence "CR LF" must be treated as a single "new
+line" character and used whenever their combined action is
+intended; the sequence "CR NUL" must be used where a carriage
+return alone is actually desired; and the CR character must be
+avoided in other contexts.  This rule gives assurance to systems
+which must decide whether to perform a "new line" function or a
+multiple-backspace that the TELNET stream contains a character
+following a CR that will allow a rational decision.
+(in the default ASCII mode), to preserve the symmetry of the
+NVT model.  Even though it may be known in some situations
+(e.g., with remote echo and suppress go ahead options in
+effect) that characters are not being sent to an actual
+printer, nonetheless, for the sake of consistency, the protocol
+requires that a NUL be inserted following a CR not followed by
+a LF in the data stream.  The converse of this is that a NUL
+received in the data stream after a CR (in the absence of
+options negotiations which explicitly specify otherwise) should
+be stripped out prior to applying the NVT to local character
+set mapping.
+`
+
+func TestWriteRead(t *testing.T) {
+	var one bytes.Buffer
+	to := ToReader(strings.NewReader(text))
+	one.ReadFrom(to)
+	two := &bytes.Buffer{}
+	from := FromWriter(two)
+	one.WriteTo(from)
+	text2, _ := ioutil.ReadAll(two)
+	if text != string(text2) {
+		t.Errorf("text mismatch \n%x \n%x", text, text2)
+	}
+}
+
+func TestOneByte(t *testing.T) {
+	var one bytes.Buffer
+	to := iotest.OneByteReader(ToReader(strings.NewReader(text)))
+	one.ReadFrom(to)
+	two := &bytes.Buffer{}
+	from := FromWriter(two)
+	one.WriteTo(from)
+	text2, _ := ioutil.ReadAll(two)
+	if text != string(text2) {
+		t.Errorf("text mismatch \n%x \n%x", text, text2)
+	}
+}

--- a/packet.go
+++ b/packet.go
@@ -7,168 +7,135 @@ import (
 	"strings"
 )
 
-type Packet interface {
-	Unpack(data []byte) error
-	Pack() []byte
-}
-
 const (
-	OP_RRQ   = uint16(1) // Read request (RRQ)
-	OP_WRQ   = uint16(2) // Write request (WRQ)
-	OP_DATA  = uint16(3) // Data
-	OP_ACK   = uint16(4) // Acknowledgement
-	OP_ERROR = uint16(5) // Error
+	opRRQ   = uint16(1) // Read request (RRQ)
+	opWRQ   = uint16(2) // Write request (WRQ)
+	opDATA  = uint16(3) // Data
+	opACK   = uint16(4) // Acknowledgement
+	opERROR = uint16(5) // Error
+	opOACK  = uint16(6) // Options Acknowledgment
 )
 
 const (
-	BLOCK_SIZE        = 512
-	MAX_DATAGRAM_SIZE = 516
+	blockLength    = 512
+	datagramLength = 516
 )
 
-type RRQ struct {
-	Filename string
-	Mode     string
+// RRQ/WRQ packet
+//
+//  2 bytes     string    1 byte    string    1 byte
+// --------------------------------------------------
+// | Opcode |  Filename  |   0  |    Mode    |   0  |
+// --------------------------------------------------
+type pRRQ []byte
+type pWRQ []byte
+
+// packRQ returns length of the packet in b
+func packRQ(b []byte, op uint16, filename, mode string) int {
+	binary.BigEndian.PutUint16(b, op)
+	n := copy(b[2:len(b)-10], filename)
+	b[2+n] = 0
+	m := copy(b[3+n:len(b)-2], mode)
+	b[2+n+1+m] = 0
+	return 2 + n + 1 + m + 1
 }
 
-func (p *RRQ) Unpack(data []byte) (e error) {
-	p.Filename, p.Mode, e = unpackRQ(data)
-	if e != nil {
-		return e
-	}
-	return nil
-}
-
-func (p *RRQ) Pack() []byte {
-	return packRQ(p.Filename, p.Mode, OP_RRQ)
-}
-
-type WRQ struct {
-	Filename string
-	Mode     string
-}
-
-func (p *WRQ) Unpack(data []byte) (e error) {
-	p.Filename, p.Mode, e = unpackRQ(data)
-	if e != nil {
-		return e
-	}
-	return nil
-}
-
-func (p *WRQ) Pack() []byte {
-	return packRQ(p.Filename, p.Mode, OP_WRQ)
-}
-
-func unpackRQ(data []byte) (filename string, mode string, e error) {
-	buffer := bytes.NewBuffer(data[2:])
-	s, e := buffer.ReadString(0x0)
-	if e != nil {
-		return s, "", e
+func unpackRQ(p []byte) (filename, mode string, err error) {
+	buffer := bytes.NewBuffer(p[2:])
+	s, err := buffer.ReadString(0x0)
+	if err != nil {
+		return s, "", err
 	}
 	filename = strings.TrimSpace(strings.Trim(s, "\x00"))
-	s, e = buffer.ReadString(0x0)
-	if e != nil {
-		return filename, s, e
+	s, err = buffer.ReadString(0x0)
+	if err != nil {
+		return filename, s, err
 	}
-	mode = strings.TrimSpace(s)
+	mode = strings.TrimSpace(strings.Trim(s, "\x00"))
 	return filename, mode, nil
 }
 
-func packRQ(filename string, mode string, opcode uint16) []byte {
-	buffer := &bytes.Buffer{}
-	binary.Write(buffer, binary.BigEndian, opcode)
-	buffer.WriteString(filename)
-	buffer.WriteByte(0x0)
-	buffer.WriteString(mode)
-	buffer.WriteByte(0x0)
-	return buffer.Bytes()
+// ERROR packet
+//
+//  2 bytes     2 bytes      string    1 byte
+// ------------------------------------------
+// | Opcode |  ErrorCode |   ErrMsg   |  0  |
+// ------------------------------------------
+type pERROR []byte
+
+func packERROR(p []byte, code uint16, message string) int {
+	binary.BigEndian.PutUint16(p, opERROR)
+	binary.BigEndian.PutUint16(p[2:], code)
+	n := copy(p[4:len(p)-2], message)
+	p[4+n] = 0
+	return n + 5
 }
 
-type DATA struct {
-	BlockNumber uint16
-	Data        []byte
+func (p pERROR) code() uint16 {
+	return binary.BigEndian.Uint16(p[2:])
 }
 
-func (p *DATA) Unpack(data []byte) (e error) {
-	if len(data) < 4 { // DATA packet must have Opcode (2 bytes) and Block # (2 bytes)
-		return fmt.Errorf("invalid DATA packet (length = %d)", len(data))
+func (p pERROR) message() string {
+	return string(p[4:])
+}
+
+// DATA packet
+//
+//  2 bytes    2 bytes     n bytes
+// ----------------------------------
+// | Opcode |   Block #  |   Data   |
+// ----------------------------------
+type pDATA []byte
+
+func (p pDATA) block() uint16 {
+	return binary.BigEndian.Uint16(p[2:])
+}
+
+// ACK packet
+//
+//  2 bytes    2 bytes
+// -----------------------
+// | Opcode |   Block #  |
+// -----------------------
+type pACK []byte
+
+func (p pACK) block() uint16 {
+	return binary.BigEndian.Uint16(p[2:])
+}
+
+func parsePacket(p []byte) (interface{}, error) {
+	l := len(p)
+	if l < 2 {
+		return nil, fmt.Errorf("short packet")
 	}
-	p.BlockNumber = binary.BigEndian.Uint16(data[2:])
-	p.Data = data[4:]
-	return nil
-}
-
-func (p *DATA) Pack() []byte {
-	buffer := &bytes.Buffer{}
-	binary.Write(buffer, binary.BigEndian, OP_DATA)
-	binary.Write(buffer, binary.BigEndian, p.BlockNumber)
-	buffer.Write(p.Data)
-	return buffer.Bytes()
-}
-
-type ACK struct {
-	BlockNumber uint16
-}
-
-func (p *ACK) Unpack(data []byte) (e error) {
-	if len(data) < 4 { // ACK packet must have Opcode (2 bytes) and Block # (2 bytes)
-		return fmt.Errorf("invalid ACK packet (length = %d)", len(data))
-	}
-	p.BlockNumber = binary.BigEndian.Uint16(data[2:])
-	return nil
-}
-
-func (p *ACK) Pack() []byte {
-	buffer := &bytes.Buffer{}
-	binary.Write(buffer, binary.BigEndian, OP_ACK)
-	binary.Write(buffer, binary.BigEndian, p.BlockNumber)
-	return buffer.Bytes()
-}
-
-type ERROR struct {
-	ErrorCode    uint16
-	ErrorMessage string
-}
-
-func (p *ERROR) Unpack(data []byte) (e error) {
-	p.ErrorCode = binary.BigEndian.Uint16(data[2:])
-	if len(data) < 4 { // ACK packet must have Opcode (2 bytes) and ErrorCode (2 bytes)
-		return fmt.Errorf("invalid ERROR packet (length = %d)", len(data))
-	}
-	buffer := bytes.NewBuffer(data[4:])
-	s, e := buffer.ReadString(0x0)
-	if e != nil {
-		return e
-	}
-	p.ErrorMessage = strings.TrimSpace(s)
-	return nil
-}
-
-func (p *ERROR) Pack() []byte {
-	buffer := &bytes.Buffer{}
-	binary.Write(buffer, binary.BigEndian, OP_ERROR)
-	binary.Write(buffer, binary.BigEndian, p.ErrorCode)
-	buffer.WriteString(p.ErrorMessage)
-	buffer.WriteByte(0x0)
-	return buffer.Bytes()
-}
-
-func ParsePacket(data []byte) (Packet, error) {
-	var p Packet
-	opcode := binary.BigEndian.Uint16(data)
+	opcode := binary.BigEndian.Uint16(p)
 	switch opcode {
-	case OP_RRQ:
-		p = &RRQ{}
-	case OP_WRQ:
-		p = &WRQ{}
-	case OP_DATA:
-		p = &DATA{}
-	case OP_ACK:
-		p = &ACK{}
-	case OP_ERROR:
-		p = &ERROR{}
+	case opRRQ:
+		if l < 4 {
+			return nil, fmt.Errorf("short RRQ packet: %d", l)
+		}
+		return pRRQ(p), nil
+	case opWRQ:
+		if l < 4 {
+			return nil, fmt.Errorf("short WRQ packet: %d", l)
+		}
+		return pWRQ(p), nil
+	case opDATA:
+		if l < 4 {
+			return nil, fmt.Errorf("short DATA packet: %d", l)
+		}
+		return pDATA(p), nil
+	case opACK:
+		if l < 4 {
+			return nil, fmt.Errorf("short ACK packet: %d", l)
+		}
+		return pACK(p), nil
+	case opERROR:
+		if l < 5 {
+			return nil, fmt.Errorf("short ERROR packet: %d", l)
+		}
+		return pERROR(p), nil
 	default:
 		return nil, fmt.Errorf("unknown opcode: %d", opcode)
 	}
-	return p, p.Unpack(data)
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,15 @@
+package tftp
+
+import "net"
+
+func transmissionConn() (*net.UDPConn, error) {
+	addr, e := net.ResolveUDPAddr("udp", ":0")
+	if e != nil {
+		return nil, e
+	}
+	conn, e := net.ListenUDP("udp", addr)
+	if e != nil {
+		return nil, e
+	}
+	return conn, nil
+}


### PR DESCRIPTION
This is big and API breaking change.

Old code is available as release 0.1: https://github.com/pin/tftp/tree/0.1