### PR TITLE
make server determine outgoing transfer size using seek

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -11,6 +11,11 @@ import (
 	"github.com/pin/tftp/netascii"
 )
 
+// IncomingTransfer allows to obtain size of incoming file in case it
+// is received with tsize option (see RFC2349).
+//
+// To tell the zero-sized file transfer from no tsize provided use
+// second boolean "ok" retrun value.
 type IncomingTransfer interface {
 	Size() (n int64, ok bool)
 }

--- a/sender.go
+++ b/sender.go
@@ -11,6 +11,17 @@ import (
 	"github.com/pin/tftp/netascii"
 )
 
+// OutgoingTransfer is an interface to set outgoing transfer size
+// (tsize option: RFC2349) manually in server write transfer
+// handler.
+//
+// It is not necessary in most cases and when io.Reader provided to
+// ReadFrom satisfies also io.Seeker (e.g. os.File) transfer size will
+// be determined automatically. Seek will not be attempted in case
+// transfer size option is set with SetSize.
+//
+// Value provided will be used only if SetSize called before ReadFrom
+// and only on in server read handler.
 type OutgoingTransfer interface {
 	SetSize(n int64)
 }

--- a/server.go
+++ b/server.go
@@ -9,8 +9,9 @@ import (
 )
 
 // NewServer creates TFTP server. It requires two functions to handle
-// read and write requests. In case nil is provided for read or write
-// handler the respective operation is disabled.
+// read and write requests.
+// In case nil is provided for read or write handler the respective
+// operation is disabled.
 func NewServer(readHandler func(filename string, rf io.ReaderFrom) error,
 	writeHandler func(filename string, wt io.WriterTo) error) *Server {
 	return &Server{
@@ -31,7 +32,8 @@ type Server struct {
 	retries      int
 }
 
-// SetTimeout sets maximum time server waits for single network round-trip to succeed.
+// SetTimeout sets maximum time server waits for single network
+// round-trip to succeed.
 // Default is 5 seconds.
 func (s *Server) SetTimeout(t time.Duration) {
 	if t <= 0 {
@@ -40,7 +42,8 @@ func (s *Server) SetTimeout(t time.Duration) {
 	s.timeout = t
 }
 
-// SetRetries sets maximum number of attempts server made to transmit a packet.
+// SetRetries sets maximum number of attempts server made to transmit a
+// packet.
 // Default is 5 attempts.
 func (s *Server) SetRetries(count int) {
 	if count < 1 {


### PR DESCRIPTION
Use `Seek` in case sender asked to send tsize option and provided to `ReadFrom` method `io.Reader` satisfies `io.Seeker` interface.