### PR TITLE
Validate IP address and port of received packets

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,11 +68,10 @@ func (c Client) Send(filename string, mode string) (io.ReaderFrom, error) {
 		s.opts["blksize"] = strconv.Itoa(c.blksize)
 	}
 	n := packRQ(s.send, opWRQ, filename, mode, s.opts)
-	addr, err := s.sendWithRetry(n)
+	err = s.sendWithRetry(n)
 	if err != nil {
 		return nil, err
 	}
-	s.addr = addr
 	s.opts = nil
 	return s, nil
 }

--- a/receiver.go
+++ b/receiver.go
@@ -156,7 +156,7 @@ func (r *receiver) receiveDatagram(l int) (int, *net.UDPAddr, error) {
 			return 0, nil, err
 		}
 		if !addr.IP.Equal(r.addr.IP) || (r.tid != 0 && addr.Port != r.tid) {
-			return 0, nil, err
+			continue
 		}
 		p, err := parsePacket(r.receive[:c])
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -116,7 +116,7 @@ func (s *Server) processRequest(conn *net.UDPConn) error {
 			return fmt.Errorf("unpack WRQ: %v", err)
 		}
 		//fmt.Printf("got WRQ (filename=%s, mode=%s, opts=%v)\n", filename, mode, opts)
-		conn, err := net.ListenUDP(udp, &net.UDPAddr{})
+		conn, err := net.DialUDP("udp", nil, remoteAddr)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func (s *Server) processRequest(conn *net.UDPConn) error {
 			return fmt.Errorf("unpack RRQ: %v", err)
 		}
 		//fmt.Printf("got RRQ (filename=%s, mode=%s, opts=%v)\n", filename, mode, opts)
-		conn, err := net.ListenUDP(udp, &net.UDPAddr{})
+		conn, err := net.DialUDP("udp", nil, remoteAddr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change alters the sender logic to use a connected UDP socket which guarantees that packets which arrive on the socket originated from the correct IP and port.

Receiver logic has been updated to always validate the remote IP address.  Port (TFTP TID) is validated upon receipt of the first response packet from the server.