### PR TITLE
Add LocalAddr() to Incoming and Outgoing transfer interfaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,23 @@ func readHandler(filename string, rf io.ReaderFrom) error {
 Similarly, it is possible to obtain size of a file that is about to be
 received using `IncomingTransfer` interface (see `Size` method).
 
-Remote Address
---------------
+Local and Remote Address
+------------------------
 
-The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide the
-`RemoteAddr` method which returns the peer IP address and port as a
-`net.UDPAddr`.  This can be used for detailed logging in a server handler.
+The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide
+the `RemoteAddr` method which returns the peer IP address and port as
+a `net.UDPAddr`, and a `LocalAddr` method with returns the local IP
+address and port as a `net.Addr` the request is being handled on.
+These can be used for detailed logging in a server handler, among other thinfs
 
 ```go
 
 func readHandler(filename string, rf io.ReaderFrom) error {
         ...
         raddr := rf.(tftp.OutgoingTransfer).RemoteAddr()
-        log.Println("RRQ from", raddr.String())
+        laddr := rf.(tftp.OutgoingTransfer).LocalAddr()
+        log.Println("RRQ from", raddr.String(), "To ",laddr.String())
+        log.Println("")
         ...
         // ReadFrom ...
 ```

--- a/receiver.go
+++ b/receiver.go
@@ -21,9 +21,12 @@ type IncomingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
+	// LocalAddr returns the IP address and port we are servicing the request on
+	LocalAddr() net.Addr
 }
 
 func (r *receiver) RemoteAddr() net.UDPAddr { return *r.addr }
+func (r *receiver) LocalAddr() net.Addr     { return r.conn.LocalAddr() }
 
 func (r *receiver) Size() (n int64, ok bool) {
 	if r.opts != nil {

--- a/receiver.go
+++ b/receiver.go
@@ -26,7 +26,7 @@ type IncomingTransfer interface {
 }
 
 func (r *receiver) RemoteAddr() net.UDPAddr { return *r.addr }
-func (r *receiver) LocalAddr() net.Addr     { return r.conn.LocalAddr() }
+func (r *receiver) LocalAddr() net.Addr     { return r.localAddr }
 
 func (r *receiver) Size() (n int64, ok bool) {
 	if r.opts != nil {
@@ -42,20 +42,21 @@ func (r *receiver) Size() (n int64, ok bool) {
 }
 
 type receiver struct {
-	send     []byte
-	receive  []byte
-	addr     *net.UDPAddr
-	tid      int
-	conn     *net.UDPConn
-	block    uint16
-	retry    *backoff
-	timeout  time.Duration
-	retries  int
-	l        int
-	autoTerm bool
-	dally    bool
-	mode     string
-	opts     options
+	send      []byte
+	receive   []byte
+	addr      *net.UDPAddr
+	localAddr net.Addr
+	tid       int
+	conn      *net.UDPConn
+	block     uint16
+	retry     *backoff
+	timeout   time.Duration
+	retries   int
+	l         int
+	autoTerm  bool
+	dally     bool
+	mode      string
+	opts      options
 }
 
 func (r *receiver) WriteTo(w io.Writer) (n int64, err error) {

--- a/sender.go
+++ b/sender.go
@@ -33,21 +33,22 @@ type OutgoingTransfer interface {
 }
 
 type sender struct {
-	conn    *net.UDPConn
-	addr    *net.UDPAddr
-	tid     int
-	send    []byte
-	receive []byte
-	retry   *backoff
-	timeout time.Duration
-	retries int
-	block   uint16
-	mode    string
-	opts    options
+	conn      *net.UDPConn
+	addr      *net.UDPAddr
+	localAddr net.Addr
+	tid       int
+	send      []byte
+	receive   []byte
+	retry     *backoff
+	timeout   time.Duration
+	retries   int
+	block     uint16
+	mode      string
+	opts      options
 }
 
 func (s *sender) RemoteAddr() net.UDPAddr { return *s.addr }
-func (s *sender) LocalAddr() net.Addr     { return s.conn.LocalAddr() }
+func (s *sender) LocalAddr() net.Addr     { return s.localAddr }
 
 func (s *sender) SetSize(n int64) {
 	if s.opts != nil {

--- a/sender.go
+++ b/sender.go
@@ -28,6 +28,8 @@ type OutgoingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
+	// LocalAddr returns the IP address and port we are servicing the request on
+	LocalAddr() net.Addr
 }
 
 type sender struct {
@@ -45,6 +47,7 @@ type sender struct {
 }
 
 func (s *sender) RemoteAddr() net.UDPAddr { return *s.addr }
+func (s *sender) LocalAddr() net.Addr     { return s.conn.LocalAddr() }
 
 func (s *sender) SetSize(n int64) {
 	if s.opts != nil {

--- a/server.go
+++ b/server.go
@@ -111,6 +111,7 @@ func (s *Server) processRequest(conn *net.UDPConn) error {
 	var buffer []byte
 	buffer = make([]byte, datagramLength)
 	n, remoteAddr, err := conn.ReadFromUDP(buffer)
+	localAddr := conn.LocalAddr()
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
@@ -133,15 +134,16 @@ func (s *Server) processRequest(conn *net.UDPConn) error {
 			return fmt.Errorf("open transmission: %v", err)
 		}
 		wt := &receiver{
-			send:    make([]byte, datagramLength),
-			receive: make([]byte, datagramLength),
-			conn:    conn,
-			retry:   &backoff{handler: s.backoff},
-			timeout: s.timeout,
-			retries: s.retries,
-			addr:    remoteAddr,
-			mode:    mode,
-			opts:    opts,
+			send:      make([]byte, datagramLength),
+			receive:   make([]byte, datagramLength),
+			conn:      conn,
+			retry:     &backoff{handler: s.backoff},
+			timeout:   s.timeout,
+			retries:   s.retries,
+			addr:      remoteAddr,
+			localAddr: localAddr,
+			mode:      mode,
+			opts:      opts,
 		}
 		s.wg.Add(1)
 		go func() {
@@ -169,16 +171,17 @@ func (s *Server) processRequest(conn *net.UDPConn) error {
 			return err
 		}
 		rf := &sender{
-			send:    make([]byte, datagramLength),
-			receive: make([]byte, datagramLength),
-			tid:     remoteAddr.Port,
-			conn:    conn,
-			retry:   &backoff{handler: s.backoff},
-			timeout: s.timeout,
-			retries: s.retries,
-			addr:    remoteAddr,
-			mode:    mode,
-			opts:    opts,
+			send:      make([]byte, datagramLength),
+			receive:   make([]byte, datagramLength),
+			tid:       remoteAddr.Port,
+			conn:      conn,
+			retry:     &backoff{handler: s.backoff},
+			timeout:   s.timeout,
+			retries:   s.retries,
+			addr:      remoteAddr,
+			localAddr: localAddr,
+			mode:      mode,
+			opts:      opts,
 		}
 		s.wg.Add(1)
 		go func() {


### PR DESCRIPTION
This facilitates more detailed logging along with facilitating a
usecase I have which involves dynamically generating TFTP content
based on both the address of the system making the request and the
address that the host system is using to handle the request.  This is
useful in multi-homed environnments where we cannot assume that all of
the systems we act as a TFTP server for can see us at a single IP
address.