### PR TITLE
Add LocalAddr() to Incoming and Outgoing transfer interfaces.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Dmitri Popov
 Mojo Talantikite
 Giovanni Bajo
 Andrew Danforth
+Victor Lowther

--- a/README.md
+++ b/README.md
@@ -138,16 +138,22 @@ Local and Remote Address
 
 The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide
 the `RemoteAddr` method which returns the peer IP address and port as
-a `net.UDPAddr`, and a `LocalAddr` method with returns the local IP
-address and port as a `net.IP` the request is being handled on.
-These can be used for detailed logging in a server handler, among other thinfs
+a `net.UDPAddr`, and a `LocalIP` method with returns the local IP
+address and port as a `net.IP` the request is being handled on.  These
+can be used for detailed logging in a server handler, among other
+things.
+
+Note that LocalIP may return nil or an unspecified IP address
+if finding that is not supported on a particular operating system by
+the Go net libraries, or if you call it as a TFTP client.
+
 
 ```go
 
 func readHandler(filename string, rf io.ReaderFrom) error {
         ...
         raddr := rf.(tftp.OutgoingTransfer).RemoteAddr()
-        laddr := rf.(tftp.OutgoingTransfer).LocalAddr()
+        laddr := rf.(tftp.OutgoingTransfer).LocalIP()
         log.Println("RRQ from", raddr.String(), "To ",laddr.String())
         log.Println("")
         ...

--- a/README.md
+++ b/README.md
@@ -133,19 +133,23 @@ func readHandler(filename string, rf io.ReaderFrom) error {
 Similarly, it is possible to obtain size of a file that is about to be
 received using `IncomingTransfer` interface (see `Size` method).
 
-Remote Address
---------------
+Local and Remote Address
+------------------------
 
-The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide the
-`RemoteAddr` method which returns the peer IP address and port as a
-`net.UDPAddr`.  This can be used for detailed logging in a server handler.
+The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide
+the `RemoteAddr` method which returns the peer IP address and port as
+a `net.UDPAddr`, and a `LocalAddr` method with returns the local IP
+address and port as a `net.IP` the request is being handled on.
+These can be used for detailed logging in a server handler, among other thinfs
 
 ```go
 
 func readHandler(filename string, rf io.ReaderFrom) error {
         ...
         raddr := rf.(tftp.OutgoingTransfer).RemoteAddr()
-        log.Println("RRQ from", raddr.String())
+        laddr := rf.(tftp.OutgoingTransfer).LocalAddr()
+        log.Println("RRQ from", raddr.String(), "To ",laddr.String())
+        log.Println("")
         ...
         // ReadFrom ...
 ```

--- a/README.md
+++ b/README.md
@@ -138,22 +138,21 @@ Local and Remote Address
 
 The `OutgoingTransfer` and `IncomingTransfer` interfaces also provide
 the `RemoteAddr` method which returns the peer IP address and port as
-a `net.UDPAddr`, and a `LocalIP` method with returns the local IP
-address and port as a `net.IP` the request is being handled on.  These
-can be used for detailed logging in a server handler, among other
-things.
+a `net.UDPAddr`.  The `RequestPacketInfo` interface provides a
+`LocalIP` method with returns the local IP address as a `net.IP` that
+the request is being handled on.  These can be used for detailed
+logging in a server handler, among other things.
 
 Note that LocalIP may return nil or an unspecified IP address
 if finding that is not supported on a particular operating system by
 the Go net libraries, or if you call it as a TFTP client.
-
 
 ```go
 
 func readHandler(filename string, rf io.ReaderFrom) error {
         ...
         raddr := rf.(tftp.OutgoingTransfer).RemoteAddr()
-        laddr := rf.(tftp.OutgoingTransfer).LocalIP()
+        laddr := rf.(tftp.RequestPacketInfo).LocalIP()
         log.Println("RRQ from", raddr.String(), "To ",laddr.String())
         log.Println("")
         ...

--- a/receiver.go
+++ b/receiver.go
@@ -21,8 +21,6 @@ type IncomingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
-	// LocalAddr returns the IP address and port we are servicing the request on
-	LocalIP() net.IP
 }
 
 func (r *receiver) RemoteAddr() net.UDPAddr { return *r.addr }

--- a/receiver.go
+++ b/receiver.go
@@ -22,11 +22,11 @@ type IncomingTransfer interface {
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
 	// LocalAddr returns the IP address and port we are servicing the request on
-	LocalAddr() net.IP
+	LocalIP() net.IP
 }
 
 func (r *receiver) RemoteAddr() net.UDPAddr { return *r.addr }
-func (r *receiver) LocalAddr() net.IP       { return r.localAddr }
+func (r *receiver) LocalIP() net.IP         { return r.localIP }
 
 func (r *receiver) Size() (n int64, ok bool) {
 	if r.opts != nil {
@@ -42,21 +42,21 @@ func (r *receiver) Size() (n int64, ok bool) {
 }
 
 type receiver struct {
-	send      []byte
-	receive   []byte
-	addr      *net.UDPAddr
-	localAddr net.IP
-	tid       int
-	conn      *net.UDPConn
-	block     uint16
-	retry     *backoff
-	timeout   time.Duration
-	retries   int
-	l         int
-	autoTerm  bool
-	dally     bool
-	mode      string
-	opts      options
+	send     []byte
+	receive  []byte
+	addr     *net.UDPAddr
+	localIP  net.IP
+	tid      int
+	conn     *net.UDPConn
+	block    uint16
+	retry    *backoff
+	timeout  time.Duration
+	retries  int
+	l        int
+	autoTerm bool
+	dally    bool
+	mode     string
+	opts     options
 }
 
 func (r *receiver) WriteTo(w io.Writer) (n int64, err error) {

--- a/receiver.go
+++ b/receiver.go
@@ -21,9 +21,12 @@ type IncomingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
+	// LocalAddr returns the IP address and port we are servicing the request on
+	LocalAddr() net.IP
 }
 
 func (r *receiver) RemoteAddr() net.UDPAddr { return *r.addr }
+func (r *receiver) LocalAddr() net.IP       { return r.localAddr }
 
 func (r *receiver) Size() (n int64, ok bool) {
 	if r.opts != nil {
@@ -39,20 +42,21 @@ func (r *receiver) Size() (n int64, ok bool) {
 }
 
 type receiver struct {
-	send     []byte
-	receive  []byte
-	addr     *net.UDPAddr
-	tid      int
-	conn     *net.UDPConn
-	block    uint16
-	retry    *backoff
-	timeout  time.Duration
-	retries  int
-	l        int
-	autoTerm bool
-	dally    bool
-	mode     string
-	opts     options
+	send      []byte
+	receive   []byte
+	addr      *net.UDPAddr
+	localAddr net.IP
+	tid       int
+	conn      *net.UDPConn
+	block     uint16
+	retry     *backoff
+	timeout   time.Duration
+	retries   int
+	l         int
+	autoTerm  bool
+	dally     bool
+	mode      string
+	opts      options
 }
 
 func (r *receiver) WriteTo(w io.Writer) (n int64, err error) {

--- a/sender.go
+++ b/sender.go
@@ -28,7 +28,16 @@ type OutgoingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
-	// LocalAddr returns the IP address and port we are servicing the request on
+}
+
+// RequestPacketInfo provides a method of getting the local IP address
+// that is handling a UDP request.  It relies for its accuracy on the
+// OS providing methods to inspect the underlying UDP and IP packets
+// directly.
+type RequestPacketInfo interface {
+	// LocalAddr returns the IP address we are servicing the request on.
+	// If it is unable to determine what address that is, the returned
+	// net.IP will be nil.
 	LocalIP() net.IP
 }
 

--- a/sender.go
+++ b/sender.go
@@ -29,26 +29,26 @@ type OutgoingTransfer interface {
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
 	// LocalAddr returns the IP address and port we are servicing the request on
-	LocalAddr() net.IP
+	LocalIP() net.IP
 }
 
 type sender struct {
-	conn      *net.UDPConn
-	addr      *net.UDPAddr
-	localAddr net.IP
-	tid       int
-	send      []byte
-	receive   []byte
-	retry     *backoff
-	timeout   time.Duration
-	retries   int
-	block     uint16
-	mode      string
-	opts      options
+	conn    *net.UDPConn
+	addr    *net.UDPAddr
+	localIP net.IP
+	tid     int
+	send    []byte
+	receive []byte
+	retry   *backoff
+	timeout time.Duration
+	retries int
+	block   uint16
+	mode    string
+	opts    options
 }
 
 func (s *sender) RemoteAddr() net.UDPAddr { return *s.addr }
-func (s *sender) LocalAddr() net.IP       { return s.localAddr }
+func (s *sender) LocalIP() net.IP         { return s.localIP }
 
 func (s *sender) SetSize(n int64) {
 	if s.opts != nil {

--- a/sender.go
+++ b/sender.go
@@ -28,23 +28,27 @@ type OutgoingTransfer interface {
 
 	// RemoteAddr returns the remote peer's IP address and port.
 	RemoteAddr() net.UDPAddr
+	// LocalAddr returns the IP address and port we are servicing the request on
+	LocalAddr() net.IP
 }
 
 type sender struct {
-	conn    *net.UDPConn
-	addr    *net.UDPAddr
-	tid     int
-	send    []byte
-	receive []byte
-	retry   *backoff
-	timeout time.Duration
-	retries int
-	block   uint16
-	mode    string
-	opts    options
+	conn      *net.UDPConn
+	addr      *net.UDPAddr
+	localAddr net.IP
+	tid       int
+	send      []byte
+	receive   []byte
+	retry     *backoff
+	timeout   time.Duration
+	retries   int
+	block     uint16
+	mode      string
+	opts      options
 }
 
 func (s *sender) RemoteAddr() net.UDPAddr { return *s.addr }
+func (s *sender) LocalAddr() net.IP       { return s.localAddr }
 
 func (s *sender) SetSize(n int64) {
 	if s.opts != nil {


### PR DESCRIPTION
This facilitates more detailed logging along with facilitating a
usecase I have which involves dynamically generating TFTP content
based on both the address of the system making the request and the
address that the host system is using to handle the request.  This is
useful in multi-homed environnments where we cannot assume that all of
the systems we act as a TFTP server for can see us at a single IP
address.