### PR TITLE
Allow user to specify blocksize in Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,11 @@ func (c *Client) SetBackoff(h backoffFunc) {
 	c.backoff = h
 }
 
+// SetBlksize sets a custom block size used in the transmission.
+func (c *Client) SetBlksize(s int) {
+	c.blksize = s
+}
+
 // RequestTSize sets flag to indicate if tsize should be requested.
 func (c *Client) RequestTSize(s bool) {
 	c.tsize = s

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -256,7 +256,7 @@ func TestNotFound(t *testing.T) {
 	mode := "octet"
 	_, err := c.Receive(filename, mode)
 	if err == nil {
-		t.Fatalf("file not exists", err)
+		t.Fatalf("file not exists: %v", err)
 	}
 	t.Logf("receiving file that does not exist: %v", err)
 }


### PR DESCRIPTION
Client already has a block size field and it is being used, but there is no way to set it.