### PR TITLE
Allow for custom block size in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,11 @@ func (c *Client) SetBackoff(h backoffFunc) {
 	c.backoff = h
 }
 
+// SetBlksize sets a custom block size used in the transmission.
+func (c *Client) SetBlksize(s int) {
+	c.blksize = s
+}
+
 // RequestTSize sets flag to indicate if tsize should be requested.
 func (c *Client) RequestTSize(s bool) {
 	c.tsize = s
@@ -115,6 +120,8 @@ func (c Client) Receive(filename string, mode string) (io.WriterTo, error) {
 	}
 	if c.blksize != 0 {
 		r.opts["blksize"] = strconv.Itoa(c.blksize)
+		// Clean it up so we don't send options twice
+		defer func() { delete(r.opts, "blksize") }()
 	}
 	if c.tsize {
 		r.opts["tsize"] = "0"

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -256,7 +256,7 @@ func TestNotFound(t *testing.T) {
 	mode := "octet"
 	_, err := c.Receive(filename, mode)
 	if err == nil {
-		t.Fatalf("file not exists", err)
+		t.Fatalf("file not exists: %v", err)
 	}
 	t.Logf("receiving file that does not exist: %v", err)
 }


### PR DESCRIPTION
# Test plan
First downloaded the file with standard tftp client
```
busybox tftp -g -r /file "example.com:69" -b 1024
```
And then used a simple go program to do the same
```go
package main

import (
	"github.com/pin/tftp"
	"os"
)

const target = "example.com:69"
const blksize = 1024
const filename = "/file"
const output = "/tmp/file"

func main() {
	c, err := tftp.NewClient(target)
	if err != nil {
		panic(err)
	}
	f, err := os.Create(output)
	if err != nil {
		panic(err)
	}
	defer f.Close()
	c.SetBlksize(blksize)
	w, err := c.Receive(filename, "octet")
	if err != nil {
		panic(err)
	}
	_, err = w.WriteTo(f)
	if err != nil {
		panic(err)
	}
}
```
And standard diff
```
diff -s file /tmp/file
Files file and /tmp/file are identical
```
