### PR TITLE
experiment with the tftpd32 anticipate-window-like feature

### DIFF
--- a/sender_anticipate.go
+++ b/sender_anticipate.go
@@ -1,0 +1,198 @@
+package tftp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// the struct embedded into sender{} as sendA
+type senderAnticipate struct {
+	enabled   bool
+	winsz     uint     /* init windows size in number of buffers */
+	num       uint     /* actual packets to send. */
+	sends     [][]byte /* buffers for a number of packets */
+	sendslens []uint   /* data lens in buffers */
+}
+
+const anticipateWindowDefMax = 60 /* 60 by 512 is about 30k */
+const anticipateDebug bool = false
+
+func sendAInit(sA *senderAnticipate, ln uint, winSz uint) {
+	var ksz uint
+	if winSz > anticipateWindowDefMax {
+		ksz = anticipateWindowDefMax
+	} else if winSz < 2 {
+		ksz = 2
+	} else {
+		ksz = winSz
+	}
+	sA.sends = make([][]byte, ksz)
+	sA.sendslens = make([]uint, ksz)
+	for k := uint(0); k < ksz; k++ {
+		sA.sends[k] = make([]byte, ln)
+		sA.sendslens[k] = 0
+	}
+	sA.winsz = ksz
+	fmt.Printf("  Set packet buffer size %v\n", ln)
+}
+
+// derived from ReadFrom()
+func readFromAnticipate(s *sender, r io.Reader) (n int64, err error) {
+	s.block = 1 // start data transmission with block 1
+	ksz := uint(len(s.sendA.sends))
+	for k := uint(0); k < ksz; k++ {
+		binary.BigEndian.PutUint16(s.sendA.sends[k][0:2], opDATA)
+		s.sendA.sendslens[k] = 0
+	}
+	s.sendA.num = 0
+	for {
+		nx := int64(0)
+		knum := uint(0)
+		kfillOk := true /* default ok */
+		kfillPartial := false
+		for k := uint(0); k < ksz; k++ {
+			lx, err := io.ReadFull(r, s.sendA.sends[k][4:])
+			nx += int64(lx)
+			if err != nil && err != io.ErrUnexpectedEOF {
+				if err == io.EOF {
+					if kfillPartial {
+						break /* short packet already sent in last loop */
+					}
+					binary.BigEndian.PutUint16(s.sendA.sends[k][2:4],
+						s.block+uint16(k))
+					s.sendA.sendslens[k] = 4
+					knum = k + 1
+					kfillPartial = true
+					break
+				}
+				kfillOk = false
+				break /* fail */
+			} else if err != nil /* has to be io.ErrUnexpectedEOF now */ {
+				kfillPartial = true /* set the flag and send the packet */
+			}
+			binary.BigEndian.PutUint16(s.sendA.sends[k][2:4],
+				s.block+uint16(k))
+			s.sendA.sendslens[k] = uint(4 + lx)
+			knum = k + 1
+		}
+		if !kfillOk {
+			s.abort(err)
+			return n, err
+		}
+		s.sendA.num = knum
+		n += int64(nx)
+		if anticipateDebug {
+			fmt.Printf(" **** sends s.block %v pkts %v  ", s.block, knum)
+			for k := uint(0); k < ksz; k++ {
+				fmt.Printf(" %v ", s.sendA.sendslens[k])
+			}
+			fmt.Println("")
+		}
+		_, err = s.sendWithRetryAnticipate()
+		if err != nil {
+			s.abort(err)
+			return n, err
+		}
+		if kfillPartial {
+			s.conn.Close()
+			return n, nil
+		}
+		s.block += uint16(knum)
+	}
+}
+
+// derived from sendWithRetry()
+func (s *sender) sendWithRetryAnticipate() (*net.UDPAddr, error) {
+	s.retry.reset()
+	for {
+		addr, err := s.sendDatagramAnticipate()
+		if _, ok := err.(net.Error); ok && s.retry.count() < s.retries {
+			s.retry.backoff()
+			continue
+		}
+		return addr, err
+	}
+}
+
+// derived from sendDatagram()
+func (s *sender) sendDatagramAnticipate() (*net.UDPAddr, error) {
+	err1 := s.conn.SetReadDeadline(time.Now().Add(s.timeout))
+	if err1 != nil {
+		return nil, err1
+	}
+	var err error = nil
+	ksz := uint(len(s.sendA.sends))
+	knum := s.sendA.num
+	if knum > ksz {
+		err = fmt.Errorf("knum %v bigger than ksz %v", knum, ksz)
+		return nil, err
+	}
+
+	for k := uint(0); k < knum; k++ {
+		lx := s.sendA.sendslens[k]
+		if lx < 4 {
+			err = fmt.Errorf("lx smaller than 4")
+			break
+		}
+		_, errx := s.conn.WriteToUDP(s.sendA.sends[k][:lx], s.addr)
+		if errx != nil {
+			err = fmt.Errorf("k %v errx %v", k, errx.Error())
+			break
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	k := uint(0)
+	for {
+		n, addr, err := s.conn.ReadFromUDP(s.receive)
+		if err != nil {
+			return nil, err
+		}
+		if !addr.IP.Equal(s.addr.IP) || (s.tid != 0 && addr.Port != s.tid) {
+			continue
+		}
+		p, err := parsePacket(s.receive[:n])
+		if err != nil {
+			continue
+		}
+		s.tid = addr.Port
+		switch p := p.(type) {
+		case pACK:
+			if anticipateDebug {
+				fmt.Printf(" **** pACK p.block %v  s.block %v k %v\n",
+					p.block(), s.block, k)
+			}
+			if p.block() == s.block+uint16(k) {
+				k++
+				if k == knum {
+					return addr, nil
+				}
+			}
+		case pOACK:
+			opts, err := unpackOACK(p)
+			if s.block != 0 {
+				continue
+			}
+			if err != nil {
+				s.abort(err)
+				return addr, err
+			}
+			for name, value := range opts {
+				if name == "blksize" {
+					err := s.setBlockSize(value)
+					if err != nil {
+						continue
+					}
+				}
+			}
+			return addr, nil
+		case pERROR:
+			return nil, fmt.Errorf("sending block %d: code=%d, error: %s",
+				s.block, p.code(), p.message())
+		}
+	}
+}

--- a/sender_anticipate.go
+++ b/sender_anticipate.go
@@ -36,7 +36,7 @@ func sendAInit(sA *senderAnticipate, ln uint, winSz uint) {
 		sA.sendslens[k] = 0
 	}
 	sA.winsz = ksz
-	fmt.Printf("  Set packet buffer size %v\n", ln)
+	//fmt.Printf("  Set packet buffer size %v\n", ln)
 }
 
 // derived from ReadFrom()

--- a/server.go
+++ b/server.go
@@ -49,9 +49,23 @@ type Server struct {
 	sendAWinSz   uint
 }
 
-func (s *Server) SetAnticipate(en bool, winsz uint) {
-	s.sendAEnable = en
-	s.sendAWinSz = winsz
+// SetAnticipate provides an experimental feature in which when a packets 
+// is requested the server will keep sending a number of packets before 
+// checking whether an ack has been received. It improves tftp downloading 
+// speed by a few times. 
+// The argument winsz specifies how many packets will be sent before 
+// waiting for an ack packet. 
+// When winsz is bigger than 1, the feature is enabled, and the server 
+// runs through a different experimental code path. When winsz is 0 or 1, 
+// the feature is disabled. 
+func (s *Server) SetAnticipate(winsz uint) {
+	if winsz > 1 {
+		s.sendAEnable = true
+		s.sendAWinSz = winsz
+	} else {
+		s.sendAEnable = false
+		s.sendAWinSz = 1
+	}
 }
 
 // SetTimeout sets maximum time server waits for single network

--- a/tftp_anticipate_test.go
+++ b/tftp_anticipate_test.go
@@ -1,0 +1,41 @@
+package tftp
+
+import (
+	"net"
+	"testing"
+)
+
+// derived from Test900
+func TestAnticipateWindow900(t *testing.T) {
+	s, c := makeTestServerAnticipateWindow()
+	defer s.Shutdown()
+	for i := 600; i < 4000; i += 1 {
+		c.blksize = i
+		testSendReceive(t, c, 9000+int64(i))
+	}
+}
+
+// derived from makeTestServer
+func makeTestServerAnticipateWindow() (*Server, *Client) {
+	b := &testBackend{}
+	b.m = make(map[string][]byte)
+
+	// Create server
+	s := NewServer(b.handleRead, b.handleWrite)
+	s.SetAnticipate(16) /* senderAnticipate window size set to 16 */
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+	if err != nil {
+		panic(err)
+	}
+
+	go s.Serve(conn)
+
+	// Create client for that server
+	c, err := NewClient(localSystem(conn))
+	if err != nil {
+		panic(err)
+	}
+
+	return s, c
+}


### PR DESCRIPTION
Hi, There, 

I'm using tftp to load files to an embedded board. A non-standard feature from tftpd32 (see http://tftpd32.jounin.net/tftpd32_faq.html) called "anticipation window" improves speed a lot. On a fast-ethernet (100M port), the feature enables a 6x faster download speed, reducing 30-seconds to 5-seconds for a 60M file. 

The PR is an attempt to implement such a feature that is similar except that not yet implementing a rolling-window yet. 

Would you comment on a few questions: 

[1] Whether such a feature is something you'll be interested in adding to the project. 
[2] How do you think about this PR and what changes would be necessary to make it acceptable. Of course, if you'd do it differently it would be great too. 

The PR has been tested with a pair of example client and server, in the anticipate-window-exmple branch of the same source repo here https://github.com/goplat/tftp/tree/minghuadev-anticipate-window-example/example-anticipate-window. The result is recorded in the svr.go as a comment at the end of the file. The numbers are on local 127.0.0.1 loopback, not on a real network yet. 

Thanks. 
