### PR TITLE
Make blksize negotiation a bit smarter.

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -40,21 +40,22 @@ func (r *receiver) Size() (n int64, ok bool) {
 }
 
 type receiver struct {
-	send     []byte
-	receive  []byte
-	addr     *net.UDPAddr
-	localIP  net.IP
-	tid      int
-	conn     *net.UDPConn
-	block    uint16
-	retry    *backoff
-	timeout  time.Duration
-	retries  int
-	l        int
-	autoTerm bool
-	dally    bool
-	mode     string
-	opts     options
+	send        []byte
+	receive     []byte
+	addr        *net.UDPAddr
+	localIP     net.IP
+	tid         int
+	conn        *net.UDPConn
+	block       uint16
+	retry       *backoff
+	timeout     time.Duration
+	retries     int
+	l           int
+	autoTerm    bool
+	dally       bool
+	mode        string
+	opts        options
+	maxBlockLen int
 }
 
 func (r *receiver) WriteTo(w io.Writer) (n int64, err error) {
@@ -126,10 +127,14 @@ func (r *receiver) setBlockSize(blksize string) error {
 		return err
 	}
 	if n < 512 {
-		return fmt.Errorf("blkzise too small: %d", n)
+		return fmt.Errorf("blksize too small: %d", n)
 	}
 	if n > 65464 {
 		return fmt.Errorf("blksize too large: %d", n)
+	}
+	if r.maxBlockLen > 0 && n > r.maxBlockLen {
+		n = r.maxBlockLen
+		r.opts["blksize"] = strconv.Itoa(n)
 	}
 	r.receive = make([]byte, n+4)
 	return nil

--- a/server.go
+++ b/server.go
@@ -196,7 +196,7 @@ func (s *Server) processRequest4(conn4 *ipv4.PacketConn) error {
 	var localAddr net.IP
 	if control != nil {
 		localAddr = control.Dst
-		if intf, err := net.InterfaceByIndex(control.IfIndex); err != nil {
+		if intf, err := net.InterfaceByIndex(control.IfIndex); err == nil {
 			// mtu - ipv4 overhead - udp overhead
 			maxSz = intf.MTU - 28
 		}
@@ -214,7 +214,7 @@ func (s *Server) processRequest6(conn6 *ipv6.PacketConn) error {
 	var localAddr net.IP
 	if control != nil {
 		localAddr = control.Dst
-		if intf, err := net.InterfaceByIndex(control.IfIndex); err != nil {
+		if intf, err := net.InterfaceByIndex(control.IfIndex); err == nil {
 			// mtu - ipv6 overhead - udp overhead
 			maxSz = intf.MTU - 48
 		}

--- a/server.go
+++ b/server.go
@@ -45,19 +45,20 @@ type Server struct {
 	wg           sync.WaitGroup
 	timeout      time.Duration
 	retries      int
+	maxBlockLen  int
 	sendAEnable  bool /* senderAnticipate enable by server */
 	sendAWinSz   uint
 }
 
-// SetAnticipate provides an experimental feature in which when a packets 
-// is requested the server will keep sending a number of packets before 
-// checking whether an ack has been received. It improves tftp downloading 
-// speed by a few times. 
-// The argument winsz specifies how many packets will be sent before 
-// waiting for an ack packet. 
-// When winsz is bigger than 1, the feature is enabled, and the server 
-// runs through a different experimental code path. When winsz is 0 or 1, 
-// the feature is disabled. 
+// SetAnticipate provides an experimental feature in which when a packets
+// is requested the server will keep sending a number of packets before
+// checking whether an ack has been received. It improves tftp downloading
+// speed by a few times.
+// The argument winsz specifies how many packets will be sent before
+// waiting for an ack packet.
+// When winsz is bigger than 1, the feature is enabled, and the server
+// runs through a different experimental code path. When winsz is 0 or 1,
+// the feature is disabled.
 func (s *Server) SetAnticipate(winsz uint) {
 	if winsz > 1 {
 		s.sendAEnable = true
@@ -76,6 +77,19 @@ func (s *Server) SetTimeout(t time.Duration) {
 		s.timeout = defaultTimeout
 	} else {
 		s.timeout = t
+	}
+}
+
+// SetBlockSize sets the maximum size of an individual data block.
+// This must be a value between 512 (the default block size for TFTP)
+// and 65456 (the max size a UDP packet payload can be).
+//
+// This is an advisory value -- it will be clamped to the smaller of
+// the block size the client wants and the MTU of the interface being
+// communicated over munis overhead.
+func (s *Server) SetBlockSize(i int) {
+	if i > 512 && i < 65465 {
+		s.maxBlockLen = i
 	}
 }
 
@@ -132,12 +146,12 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 	var conn6 *ipv6.PacketConn
 	if addr.To4() != nil {
 		conn4 = ipv4.NewPacketConn(conn)
-		if err := conn4.SetControlMessage(ipv4.FlagDst, true); err != nil {
+		if err := conn4.SetControlMessage(ipv4.FlagDst|ipv4.FlagInterface, true); err != nil {
 			conn4 = nil
 		}
 	} else {
 		conn6 = ipv6.NewPacketConn(conn)
-		if err := conn6.SetControlMessage(ipv6.FlagDst, true); err != nil {
+		if err := conn6.SetControlMessage(ipv6.FlagDst|ipv6.FlagInterface, true); err != nil {
 			conn6 = nil
 		}
 	}
@@ -178,11 +192,16 @@ func (s *Server) processRequest4(conn4 *ipv4.PacketConn) error {
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
+	maxSz := blockLength
 	var localAddr net.IP
 	if control != nil {
 		localAddr = control.Dst
+		if intf, err := net.InterfaceByIndex(control.IfIndex); err != nil {
+			// mtu - ipv4 overhead - udp overhead
+			maxSz = intf.MTU - 28
+		}
 	}
-	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt)
+	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz)
 }
 
 func (s *Server) processRequest6(conn6 *ipv6.PacketConn) error {
@@ -191,11 +210,16 @@ func (s *Server) processRequest6(conn6 *ipv6.PacketConn) error {
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
+	maxSz := blockLength
 	var localAddr net.IP
 	if control != nil {
 		localAddr = control.Dst
+		if intf, err := net.InterfaceByIndex(control.IfIndex); err != nil {
+			// mtu - ipv6 overhead - udp overhead
+			maxSz = intf.MTU - 48
+		}
 	}
-	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt)
+	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz)
 }
 
 // Fallback if we had problems opening a ipv4/6 control channel
@@ -205,7 +229,7 @@ func (s *Server) processRequest() error {
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
-	return s.handlePacket(nil, srcAddr, buf, cnt)
+	return s.handlePacket(nil, srcAddr, buf, cnt, blockLength)
 }
 
 // Shutdown make server stop listening for new requests, allows
@@ -218,7 +242,13 @@ func (s *Server) Shutdown() {
 	s.wg.Wait()
 }
 
-func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n int) error {
+func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int) error {
+	if s.maxBlockLen > 0 && s.maxBlockLen < maxBlockLen {
+		maxBlockLen = s.maxBlockLen
+	}
+	if maxBlockLen < blockLength {
+		maxBlockLen = blockLength
+	}
 	p, err := parsePacket(buffer[:n])
 	if err != nil {
 		return err
@@ -238,16 +268,17 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			return fmt.Errorf("open transmission: %v", err)
 		}
 		wt := &receiver{
-			send:    make([]byte, datagramLength),
-			receive: make([]byte, datagramLength),
-			conn:    conn,
-			retry:   &backoff{handler: s.backoff},
-			timeout: s.timeout,
-			retries: s.retries,
-			addr:    remoteAddr,
-			localIP: localAddr,
-			mode:    mode,
-			opts:    opts,
+			send:        make([]byte, datagramLength),
+			receive:     make([]byte, datagramLength),
+			conn:        conn,
+			retry:       &backoff{handler: s.backoff},
+			timeout:     s.timeout,
+			retries:     s.retries,
+			addr:        remoteAddr,
+			localIP:     localAddr,
+			mode:        mode,
+			opts:        opts,
+			maxBlockLen: maxBlockLen,
 		}
 		s.wg.Add(1)
 		go func() {
@@ -274,18 +305,19 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			return err
 		}
 		rf := &sender{
-			send:    make([]byte, datagramLength),
-			sendA:   senderAnticipate{enabled:false},
-			receive: make([]byte, datagramLength),
-			tid:     remoteAddr.Port,
-			conn:    conn,
-			retry:   &backoff{handler: s.backoff},
-			timeout: s.timeout,
-			retries: s.retries,
-			addr:    remoteAddr,
-			localIP: localAddr,
-			mode:    mode,
-			opts:    opts,
+			send:        make([]byte, datagramLength),
+			sendA:       senderAnticipate{enabled: false},
+			receive:     make([]byte, datagramLength),
+			tid:         remoteAddr.Port,
+			conn:        conn,
+			retry:       &backoff{handler: s.backoff},
+			timeout:     s.timeout,
+			retries:     s.retries,
+			addr:        remoteAddr,
+			localIP:     localAddr,
+			mode:        mode,
+			opts:        opts,
+			maxBlockLen: maxBlockLen,
 		}
 		if s.sendAEnable { /* senderAnticipate if enabled in server */
 			rf.sendA.enabled = true /* pass enable from server to sender */

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -118,7 +118,8 @@ func Test900(t *testing.T) {
 	s, c := makeTestServer()
 	defer s.Shutdown()
 	for i := 600; i < 4000; i += 1 {
-		c.blksize = i
+		c.SetBlockSize(i)
+		s.SetBlockSize(4600 - i)
 		testSendReceive(t, c, 9000+int64(i))
 	}
 }
@@ -146,7 +147,7 @@ func Test1000(t *testing.T) {
 func Test1810(t *testing.T) {
 	s, c := makeTestServer()
 	defer s.Shutdown()
-	c.blksize = 1810
+	c.SetBlockSize(1810)
 	testSendReceive(t, c, 9000+1810)
 }
 


### PR DESCRIPTION
If we are negotiating blksize, and acting as a server, do not just
agree with the blocksize the client wants us to use.  Instead, look up
the mtu of the interface we recieved the packet on, shave off
overhead, and if that is smaller than the requested blksize try to
negotiate that instead.  This is intended to work around embedded IP
stacks that do not calcualte their buffer size properly based on the
MTU that DHCP hands them, and is a lame attempt to work around
middleboxes that eat fragmented IP packets.

While we are at it, give Server a MaxBlockSize() method to match the
one the Client has.