### PR TITLE
Single port mode

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Giovanni Bajo
 Andrew Danforth
 Victor Lowther
 minghuadev on github.com
+Owen Mooney

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func (c Client) Send(filename string, mode string) (io.ReaderFrom, error) {
 	s := &sender{
 		send:    make([]byte, datagramLength),
 		receive: make([]byte, datagramLength),
-		conn:    conn,
+		conn:    &connConnection{conn: conn},
 		retry:   &backoff{handler: c.backoff},
 		timeout: c.timeout,
 		retries: c.retries,
@@ -106,7 +106,7 @@ func (c Client) Receive(filename string, mode string) (io.WriterTo, error) {
 	r := &receiver{
 		send:     make([]byte, datagramLength),
 		receive:  make([]byte, datagramLength),
-		conn:     conn,
+		conn:     &connConnection{conn: conn},
 		retry:    &backoff{handler: c.backoff},
 		timeout:  c.timeout,
 		retries:  c.retries,

--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,101 @@
+package tftp
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+type connectionError struct {
+	error
+	timeout   bool
+	temporary bool
+}
+
+func (t *connectionError) Timeout() bool {
+	return t.timeout
+}
+
+func (t *connectionError) Temporary() bool {
+	return t.temporary
+}
+
+type connection interface {
+	sendTo([]byte, *net.UDPAddr) error
+	readFrom([]byte) (int, *net.UDPAddr, error)
+	setDeadline(time.Duration) error
+	close()
+}
+
+type connConnection struct {
+	conn *net.UDPConn
+}
+
+type chanConnection struct {
+	sendConn *net.UDPConn
+	channel  chan []byte
+	addr     *net.UDPAddr
+	timeout  time.Duration
+	complete chan string
+}
+
+func (c *chanConnection) sendTo(data []byte, addr *net.UDPAddr) error {
+	_, err := c.sendConn.WriteToUDP(data, addr)
+	return err
+}
+
+func (c *chanConnection) readFrom(buffer []byte) (int, *net.UDPAddr, error) {
+	select {
+	case data := <-c.channel:
+		for i := range data {
+			buffer[i] = data[i]
+		}
+		return len(data), c.addr, nil
+	case <-time.After(c.timeout):
+		return 0, nil, makeError(c.addr.String())
+	}
+}
+
+func (c *chanConnection) setDeadline(deadline time.Duration) error {
+	c.timeout = deadline
+	return nil
+}
+
+func (c *chanConnection) close() {
+	close(c.channel)
+	c.complete <- c.addr.String()
+}
+
+func (c *connConnection) sendTo(data []byte, addr *net.UDPAddr) error {
+	_, err := c.conn.WriteToUDP(data, addr)
+	return err
+}
+
+func makeError(addr string) net.Error {
+	error := connectionError{
+		timeout:   true,
+		temporary: true,
+	}
+	error.error = fmt.Errorf("Channel timeout: %v", addr)
+	return &error
+}
+
+func (c *connConnection) readFrom(buffer []byte) (int, *net.UDPAddr, error) {
+	n, addr, err := c.conn.ReadFromUDP(buffer)
+	if err != nil {
+		return 0, nil, err
+	}
+	return n, addr, nil
+}
+
+func (c *connConnection) setDeadline(deadline time.Duration) error {
+	err := c.conn.SetReadDeadline(time.Now().Add(deadline))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *connConnection) close() {
+	c.conn.Close()
+}

--- a/sender_anticipate.go
+++ b/sender_anticipate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"time"
 )
 
 // the struct embedded into sender{} as sendA
@@ -97,7 +96,7 @@ func readFromAnticipate(s *sender, r io.Reader) (n int64, err error) {
 			return n, err
 		}
 		if kfillPartial {
-			s.conn.Close()
+			s.conn.close()
 			return n, nil
 		}
 		s.block += uint16(knum)
@@ -119,7 +118,7 @@ func (s *sender) sendWithRetryAnticipate() (*net.UDPAddr, error) {
 
 // derived from sendDatagram()
 func (s *sender) sendDatagramAnticipate() (*net.UDPAddr, error) {
-	err1 := s.conn.SetReadDeadline(time.Now().Add(s.timeout))
+	err1 := s.conn.setDeadline(s.timeout)
 	if err1 != nil {
 		return nil, err1
 	}
@@ -137,7 +136,7 @@ func (s *sender) sendDatagramAnticipate() (*net.UDPAddr, error) {
 			err = fmt.Errorf("lx smaller than 4")
 			break
 		}
-		_, errx := s.conn.WriteToUDP(s.sendA.sends[k][:lx], s.addr)
+		errx := s.conn.sendTo(s.sendA.sends[k][:lx], s.addr)
 		if errx != nil {
 			err = fmt.Errorf("k %v errx %v", k, errx.Error())
 			break
@@ -148,7 +147,7 @@ func (s *sender) sendDatagramAnticipate() (*net.UDPAddr, error) {
 	}
 	k := uint(0)
 	for {
-		n, addr, err := s.conn.ReadFromUDP(s.receive)
+		n, addr, err := s.conn.readFrom(s.receive)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -17,24 +17,37 @@ import (
 // operation is disabled.
 func NewServer(readHandler func(filename string, rf io.ReaderFrom) error,
 	writeHandler func(filename string, wt io.WriterTo) error) *Server {
-	return &Server{
-		readHandler:  readHandler,
-		writeHandler: writeHandler,
-		timeout:      defaultTimeout,
-		retries:      defaultRetries,
-	}
+	s := newServerWithDefaults()
+	s.readHandler = readHandler
+	s.writeHandler = writeHandler
+	return s
 }
 
 // NewServerWithAddr creates a new server with read and write handlers
 // These handlers will have access to the remote address of the incoming connection
 func NewServerWithAddr(readHandlerWithAddr func(filename string, addr *net.UDPAddr, rf io.ReaderFrom) error,
 	writeWithAddrHandler func(filename string, addr *net.UDPAddr, wt io.WriterTo) error) *Server {
-	return &Server{
-		readWithAddrHandler:  readHandlerWithAddr,
-		writeWithAddrHandler: writeWithAddrHandler,
-		timeout:              defaultTimeout,
-		retries:              defaultRetries,
+	s := newServerWithDefaults()
+	s.readWithAddrHandler = readHandlerWithAddr
+	s.writeWithAddrHandler = writeWithAddrHandler
+	return s
+}
+
+func newServerWithDefaults() *Server {
+	s := &Server{
+		timeout:           defaultTimeout,
+		retries:           defaultRetries,
+		runGC:             make(chan []string),
+		gcInterval:        1 * time.Minute,
+		packetReadTimeout: 100 * time.Millisecond,
 	}
+	// pool to reuse packet buffers
+	s.bufPool = sync.Pool{
+		New: func() interface{} {
+			return make([]byte, datagramLength)
+		},
+	}
+	return s
 }
 
 // RequestPacketInfo provides a method of getting the local IP address
@@ -49,32 +62,29 @@ type RequestPacketInfo interface {
 }
 
 type Server struct {
-<<<<<<< HEAD
-	readHandler  func(filename string, rf io.ReaderFrom) error
-	writeHandler func(filename string, wt io.WriterTo) error
-	backoff      backoffFunc
-	conn         *net.UDPConn
-	quit         chan chan struct{}
-	wg           sync.WaitGroup
-	timeout      time.Duration
-	retries      int
-	maxBlockLen  int
-	sendAEnable  bool /* senderAnticipate enable by server */
-	sendAWinSz   uint
-=======
 	readHandler          func(filename string, rf io.ReaderFrom) error
 	readWithAddrHandler  func(filename string, addr *net.UDPAddr, rf io.ReaderFrom) error
 	writeHandler         func(filename string, wt io.WriterTo) error
 	writeWithAddrHandler func(filename string, addr *net.UDPAddr, wt io.WriterTo) error
 	backoff              backoffFunc
 	conn                 *net.UDPConn
+	conn6                *ipv6.PacketConn
+	conn4                *ipv4.PacketConn
 	quit                 chan chan struct{}
 	wg                   sync.WaitGroup
 	timeout              time.Duration
 	retries              int
+	maxBlockLen          int
 	sendAEnable          bool /* senderAnticipate enable by server */
 	sendAWinSz           uint
->>>>>>> 992b692... Add access to remoteAddr in handlers
+	// Single port fields
+	singlePort        bool
+	bufPool           sync.Pool
+	handlers          map[string]chan []byte
+	runGC             chan []string
+	gcCollect         chan string
+	gcInterval        time.Duration
+	packetReadTimeout time.Duration
 }
 
 // SetAnticipate provides an experimental feature in which when a packets
@@ -94,6 +104,18 @@ func (s *Server) SetAnticipate(winsz uint) {
 		s.sendAEnable = false
 		s.sendAWinSz = 1
 	}
+}
+
+// EnableSinglePort enables an experimental mode where the server will
+// serve all connections on port 69 only. There will be no random TIDs
+// on the server side.
+//
+// Enabling this will negatively impact performance
+func (s *Server) EnableSinglePort() {
+	s.singlePort = true
+	s.handlers = make(map[string]chan []byte, datagramLength)
+	s.gcCollect = make(chan string)
+	go s.internalGC()
 }
 
 // SetTimeout sets maximum time server waits for single network
@@ -169,40 +191,43 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 	if addr == nil {
 		return fmt.Errorf("Failed to determine IP class of listening address")
 	}
-	var conn4 *ipv4.PacketConn
-	var conn6 *ipv6.PacketConn
 	if addr.To4() != nil {
-		conn4 = ipv4.NewPacketConn(conn)
-		if err := conn4.SetControlMessage(ipv4.FlagDst|ipv4.FlagInterface, true); err != nil {
-			conn4 = nil
+		s.conn4 = ipv4.NewPacketConn(conn)
+		if err := s.conn4.SetControlMessage(ipv4.FlagDst|ipv4.FlagInterface, true); err != nil {
+			s.conn4 = nil
 		}
 	} else {
-		conn6 = ipv6.NewPacketConn(conn)
-		if err := conn6.SetControlMessage(ipv6.FlagDst|ipv6.FlagInterface, true); err != nil {
-			conn6 = nil
+		s.conn6 = ipv6.NewPacketConn(conn)
+		if err := s.conn6.SetControlMessage(ipv6.FlagDst|ipv6.FlagInterface, true); err != nil {
+			s.conn6 = nil
 		}
 	}
 
 	s.quit = make(chan chan struct{})
-	for {
-		select {
-		case q := <-s.quit:
-			q <- struct{}{}
-			return nil
-		default:
-			var err error
-			if conn4 != nil {
-				err = s.processRequest4(conn4)
-			} else if conn6 != nil {
-				err = s.processRequest6(conn6)
-			} else {
-				err = s.processRequest()
-			}
-			if err != nil {
-				// TODO: add logging handler
+	if s.singlePort {
+		s.singlePortProcessRequests()
+	} else {
+		for {
+			select {
+			case q := <-s.quit:
+				q <- struct{}{}
+				return nil
+			default:
+				var err error
+				if s.conn4 != nil {
+					err = s.processRequest4()
+				} else if s.conn6 != nil {
+					err = s.processRequest6()
+				} else {
+					err = s.processRequest()
+				}
+				if err != nil {
+					// TODO: add logging handler
+				}
 			}
 		}
 	}
+	return nil
 }
 
 // Yes, I don't really like having seperate IPv4 and IPv6 variants,
@@ -213,9 +238,9 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 // If control is nil for whatever reason (either things not being
 // implemented on a target OS or whatever other reason), localIP
 // (and hence LocalIP()) will return a nil IP address.
-func (s *Server) processRequest4(conn4 *ipv4.PacketConn) error {
+func (s *Server) processRequest4() error {
 	buf := make([]byte, datagramLength)
-	cnt, control, srcAddr, err := conn4.ReadFrom(buf)
+	cnt, control, srcAddr, err := s.conn4.ReadFrom(buf)
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
@@ -228,12 +253,12 @@ func (s *Server) processRequest4(conn4 *ipv4.PacketConn) error {
 			maxSz = intf.MTU - 28
 		}
 	}
-	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz)
+	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, nil)
 }
 
-func (s *Server) processRequest6(conn6 *ipv6.PacketConn) error {
+func (s *Server) processRequest6() error {
 	buf := make([]byte, datagramLength)
-	cnt, control, srcAddr, err := conn6.ReadFrom(buf)
+	cnt, control, srcAddr, err := s.conn6.ReadFrom(buf)
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
@@ -246,7 +271,7 @@ func (s *Server) processRequest6(conn6 *ipv6.PacketConn) error {
 			maxSz = intf.MTU - 48
 		}
 	}
-	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz)
+	return s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, nil)
 }
 
 // Fallback if we had problems opening a ipv4/6 control channel
@@ -256,7 +281,7 @@ func (s *Server) processRequest() error {
 	if err != nil {
 		return fmt.Errorf("reading UDP: %v", err)
 	}
-	return s.handlePacket(nil, srcAddr, buf, cnt, blockLength)
+	return s.handlePacket(nil, srcAddr, buf, cnt, blockLength, nil)
 }
 
 // Shutdown make server stop listening for new requests, allows
@@ -269,7 +294,7 @@ func (s *Server) Shutdown() {
 	s.wg.Wait()
 }
 
-func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int) error {
+func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int, listener chan []byte) error {
 	if s.maxBlockLen > 0 && s.maxBlockLen < maxBlockLen {
 		maxBlockLen = s.maxBlockLen
 	}
@@ -286,18 +311,9 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 		if err != nil {
 			return fmt.Errorf("unpack WRQ: %v", err)
 		}
-		//fmt.Printf("got WRQ (filename=%s, mode=%s, opts=%v)\n", filename, mode, opts)
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{})
-		if err != nil {
-			return err
-		}
-		if err != nil {
-			return fmt.Errorf("open transmission: %v", err)
-		}
 		wt := &receiver{
 			send:        make([]byte, datagramLength),
 			receive:     make([]byte, datagramLength),
-			conn:        conn,
 			retry:       &backoff{handler: s.backoff},
 			timeout:     s.timeout,
 			retries:     s.retries,
@@ -306,6 +322,22 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			mode:        mode,
 			opts:        opts,
 			maxBlockLen: maxBlockLen,
+		}
+		if s.singlePort {
+			wt.conn = &chanConnection{
+				addr:     remoteAddr,
+				channel:  listener,
+				timeout:  s.timeout,
+				sendConn: s.conn,
+				complete: s.gcCollect,
+			}
+			wt.singlePort = true
+		} else {
+			conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+			if err != nil {
+				return err
+			}
+			wt.conn = &connConnection{conn: conn}
 		}
 		s.wg.Add(1)
 		go func() {
@@ -316,7 +348,6 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 				} else {
 					wt.terminate()
 				}
-
 			} else if s.writeHandler != nil {
 				err := s.writeHandler(filename, wt)
 				if err != nil {
@@ -334,17 +365,11 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 		if err != nil {
 			return fmt.Errorf("unpack RRQ: %v", err)
 		}
-		//fmt.Printf("got RRQ (filename=%s, mode=%s, opts=%v)\n", filename, mode, opts)
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{})
-		if err != nil {
-			return err
-		}
 		rf := &sender{
 			send:        make([]byte, datagramLength),
 			sendA:       senderAnticipate{enabled: false},
 			receive:     make([]byte, datagramLength),
 			tid:         remoteAddr.Port,
-			conn:        conn,
 			retry:       &backoff{handler: s.backoff},
 			timeout:     s.timeout,
 			retries:     s.retries,
@@ -353,6 +378,21 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			mode:        mode,
 			opts:        opts,
 			maxBlockLen: maxBlockLen,
+		}
+		if s.singlePort {
+			rf.conn = &chanConnection{
+				addr:     remoteAddr,
+				channel:  listener,
+				timeout:  s.timeout,
+				sendConn: s.conn,
+				complete: s.gcCollect,
+			}
+		} else {
+			conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+			if err != nil {
+				return err
+			}
+			rf.conn = &connConnection{conn: conn}
 		}
 		if s.sendAEnable { /* senderAnticipate if enabled in server */
 			rf.sendA.enabled = true /* pass enable from server to sender */

--- a/single_port.go
+++ b/single_port.go
@@ -1,0 +1,103 @@
+package tftp
+
+import (
+	"net"
+	"time"
+)
+
+func (s *Server) singlePortProcessRequests() error {
+	var (
+		localAddr net.IP
+		cnt       int
+		srcAddr   net.Addr
+		err       error
+		buf       []byte
+	)
+	defer func() {
+		if r := recover(); r != nil {
+			// We've received a new connection on the same IP+Port tuple
+			// as a previous connection before garbage collection has occured
+			s.handlers[srcAddr.String()] = make(chan []byte)
+			go s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, blockLength, s.handlers[srcAddr.String()])
+			s.singlePortProcessRequests()
+		}
+	}()
+	for {
+		select {
+		case q := <-s.quit:
+			q <- struct{}{}
+			return nil
+		case handlersToFree := <-s.runGC:
+			for _, handler := range handlersToFree {
+				s.handlers[handler] = nil
+			}
+		default:
+			buf = s.bufPool.Get().([]byte)
+			cnt, localAddr, srcAddr, err = s.getPacket(buf)
+			if err != nil || cnt == 0 {
+				// TODO: add logging handler
+				s.bufPool.Put(buf)
+				continue
+			}
+			if receiverChannel, ok := s.handlers[srcAddr.String()]; ok {
+				select {
+				case receiverChannel <- buf[:cnt]:
+				default:
+					// We don't want to block the main loop if a channel is full
+				}
+			} else {
+				s.handlers[srcAddr.String()] = make(chan []byte, datagramLength)
+				go s.handlePacket(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, blockLength, s.handlers[srcAddr.String()])
+			}
+		}
+	}
+}
+
+func (s *Server) getPacket(buf []byte) (int, net.IP, *net.UDPAddr, error) {
+	if s.conn6 != nil {
+		// TODO: investigate why deadline is necessary
+		// ReadFrom seems to behave badly without it
+		s.conn6.SetReadDeadline(time.Now().Add(s.packetReadTimeout))
+		cnt, control, srcAddr, err := s.conn6.ReadFrom(buf)
+		if err != nil || cnt == 0 {
+			return 0, nil, nil, err
+		}
+		var localAddr net.IP
+		if control != nil {
+			localAddr = control.Dst
+		}
+		return cnt, localAddr, srcAddr.(*net.UDPAddr), nil
+	} else if s.conn4 != nil {
+		s.conn4.SetReadDeadline(time.Now().Add(s.packetReadTimeout))
+		cnt, control, srcAddr, err := s.conn4.ReadFrom(buf)
+		if err != nil || cnt == 0 {
+			return 0, nil, nil, err
+		}
+		var localAddr net.IP
+		if control != nil {
+			localAddr = control.Dst
+		}
+		return cnt, localAddr, srcAddr.(*net.UDPAddr), nil
+	} else {
+		cnt, srcAddr, err := s.conn.ReadFromUDP(buf)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+		return cnt, nil, srcAddr, nil
+	}
+}
+
+// internalGC collects all the finished signals from each connection's goroutine
+// The main loop is sent the key to be nil'ed after the gcInterval has passed
+func (s *Server) internalGC() {
+	var completedHandlers []string
+	for {
+		select {
+		case newHandler := <-s.gcCollect:
+			completedHandlers = append(completedHandlers, newHandler)
+		case <-time.After(s.gcInterval):
+			s.runGC <- completedHandlers
+			completedHandlers = nil
+		}
+	}
+}

--- a/single_port_test.go
+++ b/single_port_test.go
@@ -1,0 +1,38 @@
+package tftp
+
+import (
+	"testing"
+)
+
+func TestZeroLengthSinglePort(t *testing.T) {
+	s, c := makeTestServer(true)
+	defer s.Shutdown()
+	testSendReceive(t, c, 0)
+}
+
+func TestSendReveiveSinglePort(t *testing.T) {
+	s, c := makeTestServer(true)
+	defer s.Shutdown()
+	for i := 600; i < 1000; i++ {
+		testSendReceive(t, c, 5000+int64(i))
+	}
+}
+
+func TestSendReveiveSinglePortWithBlockSize(t *testing.T) {
+	s, c := makeTestServer(true)
+	defer s.Shutdown()
+	for i := 600; i < 1000; i++ {
+		c.blksize = i
+		testSendReceive(t, c, 5000+int64(i))
+	}
+}
+
+func TestServerSendTimeoutSinglePort(t *testing.T) {
+	s, c := makeTestServer(true)
+	serverTimeoutSendTest(s, c, t)
+}
+
+func TestServerReceiveTimeoutSinglePort(t *testing.T) {
+	s, c := makeTestServer(true)
+	serverReceiveTimeoutTest(s, c, t)
+}


### PR DESCRIPTION
Hi,

#### Proposal
I need to be able to force the TFTP server to only listen on port 69 for all incoming requests. I've implemented a working (but not  finished) version here.

#### Implementation
Basically there is a main loop which spawns goroutines for each new incoming connection and passes data via channels for existing connections. Here's a diagram:

![diagram](https://user-images.githubusercontent.com/9625527/56038114-0dea1e00-5d29-11e9-9ad6-3f91b7f71387.png)


There are some caveats to doing it this way: it's slower and block size is restricted for receiving data.
#### Questions

- Is this feature something you would consider adding to the library?

- Are there changes you would like for the high level design? 

(I'm going to clean this up more but let me know if you'd like it to work differently)

#### Notes
I've tried to keep most of the new changes in separate files so that the existing code paths are not too affected. 

_P.S. I've enabled SinglePort mode for all unit tests just so TravisCI runs on the PR_