### PR TITLE
Add success and failure hooks

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,6 +55,7 @@ func (c *Client) RequestTSize(s bool) {
 	c.tsize = s
 }
 
+// Client stores data about a single TFTP client
 type Client struct {
 	addr    *net.UDPAddr
 	timeout time.Duration

--- a/receiver.go
+++ b/receiver.go
@@ -59,6 +59,7 @@ type receiver struct {
 	singlePort  bool
 	maxBlockLen int
 	hook        Hook
+	startTime   time.Time
 }
 
 func (r *receiver) WriteTo(w io.Writer) (n int64, err error) {
@@ -250,6 +251,7 @@ func (r *receiver) buildTransferStats() TransferStats {
 		TotalBlocks: r.block,
 		Mode:        r.mode,
 		Opts:        r.opts,
+		Duration:    time.Now().Sub(r.startTime),
 	}
 }
 

--- a/sender.go
+++ b/sender.go
@@ -47,6 +47,7 @@ type sender struct {
 	mode        string
 	opts        options
 	hook        Hook
+	startTime   time.Time
 }
 
 func (s *sender) RemoteAddr() net.UDPAddr { return *s.addr }
@@ -260,6 +261,7 @@ func (s *sender) buildTransferStats() TransferStats {
 		TotalBlocks:             s.block,
 		Mode:                    s.mode,
 		Opts:                    s.opts,
+		Duration:                time.Now().Sub(s.startTime),
 	}
 }
 

--- a/sender_anticipate.go
+++ b/sender_anticipate.go
@@ -122,7 +122,7 @@ func (s *sender) sendDatagramAnticipate() (*net.UDPAddr, error) {
 	if err1 != nil {
 		return nil, err1
 	}
-	var err error = nil
+	var err error
 	ksz := uint(len(s.sendA.sends))
 	knum := s.sendA.num
 	if knum > ksz {

--- a/server.go
+++ b/server.go
@@ -75,6 +75,7 @@ type TransferStats struct {
 	TotalBlocks             uint16
 	Mode                    string
 	Opts                    options
+	Duration                time.Duration
 }
 
 // Hook is an interface used to provide the server with success and failure hooks
@@ -332,6 +333,7 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			maxBlockLen: maxBlockLen,
 			hook:        s.hook,
 			filename:    filename,
+			startTime:   time.Now(),
 		}
 		if s.singlePort {
 			wt.conn = &chanConnection{
@@ -383,6 +385,7 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			maxBlockLen: maxBlockLen,
 			hook:        s.hook,
 			filename:    filename,
+			startTime:   time.Now(),
 		}
 		if s.singlePort {
 			rf.conn = &chanConnection{

--- a/server.go
+++ b/server.go
@@ -21,7 +21,7 @@ func NewServer(readHandler func(filename string, rf io.ReaderFrom) error,
 		timeout:           defaultTimeout,
 		retries:           defaultRetries,
 		runGC:             make(chan []string),
-		gcInterval:        1 * time.Minute,
+		gcThreshold:       100,
 		packetReadTimeout: 100 * time.Millisecond,
 		readHandler:       readHandler,
 		writeHandler:      writeHandler,
@@ -40,9 +40,11 @@ type RequestPacketInfo interface {
 	LocalIP() net.IP
 }
 
+// Server is an instance of a TFTP server
 type Server struct {
 	readHandler  func(filename string, rf io.ReaderFrom) error
 	writeHandler func(filename string, wt io.WriterTo) error
+	hook         Hook
 	backoff      backoffFunc
 	conn         *net.UDPConn
 	conn6        *ipv6.PacketConn
@@ -60,8 +62,25 @@ type Server struct {
 	handlers          map[string]chan []byte
 	runGC             chan []string
 	gcCollect         chan string
-	gcInterval        time.Duration
+	gcThreshold       int
 	packetReadTimeout time.Duration
+}
+
+// TransferStats contains details about a single TFTP transfer
+type TransferStats struct {
+	RemoteAddr              net.IP
+	Filename                string
+	Tid                     int
+	SenderAnticipateEnabled bool
+	TotalBlocks             uint16
+	Mode                    string
+	Opts                    options
+}
+
+// Hook is an interface used to provide the server with success and failure hooks
+type Hook interface {
+	OnSuccess(stats TransferStats)
+	OnFailure(stats TransferStats, err error)
 }
 
 // SetAnticipate provides an experimental feature in which when a packets
@@ -81,6 +100,11 @@ func (s *Server) SetAnticipate(winsz uint) {
 		s.sendAEnable = false
 		s.sendAWinSz = 1
 	}
+}
+
+// SetHook sets the Hook for success and failure of transfers
+func (s *Server) SetHook(hook Hook) {
+	s.hook = hook
 }
 
 // EnableSinglePort enables an experimental mode where the server will
@@ -203,8 +227,10 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 				} else {
 					err = s.processRequest()
 				}
-				if err != nil {
-					// TODO: add logging handler
+				if err != nil && s.hook != nil {
+					s.hook.OnFailure(TransferStats{
+						SenderAnticipateEnabled: s.sendAEnable,
+					}, err)
 				}
 			}
 		}
@@ -304,6 +330,8 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			mode:        mode,
 			opts:        opts,
 			maxBlockLen: maxBlockLen,
+			hook:        s.hook,
+			filename:    filename,
 		}
 		if s.singlePort {
 			wt.conn = &chanConnection{
@@ -353,6 +381,8 @@ func (s *Server) handlePacket(localAddr net.IP, remoteAddr *net.UDPAddr, buffer 
 			mode:        mode,
 			opts:        opts,
 			maxBlockLen: maxBlockLen,
+			hook:        s.hook,
+			filename:    filename,
 		}
 		if s.singlePort {
 			rf.conn = &chanConnection{

--- a/single_port_test.go
+++ b/single_port_test.go
@@ -10,7 +10,7 @@ func TestZeroLengthSinglePort(t *testing.T) {
 	testSendReceive(t, c, 0)
 }
 
-func TestSendReveiveSinglePort(t *testing.T) {
+func TestSendReceiveSinglePort(t *testing.T) {
 	s, c := makeTestServer(true)
 	defer s.Shutdown()
 	for i := 600; i < 1000; i++ {
@@ -18,7 +18,7 @@ func TestSendReveiveSinglePort(t *testing.T) {
 	}
 }
 
-func TestSendReveiveSinglePortWithBlockSize(t *testing.T) {
+func TestSendReceiveSinglePortWithBlockSize(t *testing.T) {
 	s, c := makeTestServer(true)
 	defer s.Shutdown()
 	for i := 600; i < 1000; i++ {

--- a/tftp_anticipate_test.go
+++ b/tftp_anticipate_test.go
@@ -9,7 +9,7 @@ import (
 func TestAnticipateWindow900(t *testing.T) {
 	s, c := makeTestServerAnticipateWindow()
 	defer s.Shutdown()
-	for i := 600; i < 4000; i += 1 {
+	for i := 600; i < 4000; i++ {
 		c.blksize = i
 		testSendReceive(t, c, 9000+int64(i))
 	}


### PR DESCRIPTION
This allows you to add hooks for the success and failure of server transfers.
I also did a little bit of cleaning to make `golint` happy.

It does add `"github.com/stretchr/testify/mock"` as an external dependency. 
I haven't vendor'd it in this commit, but I can if you want.

I'm happy to make changes if necessary :)

