### PR TITLE
Add support for variable blocksize in single port mode + minor fixes

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -81,19 +81,11 @@ func makeError(addr string) net.Error {
 }
 
 func (c *connConnection) readFrom(buffer []byte) (int, *net.UDPAddr, error) {
-	n, addr, err := c.conn.ReadFromUDP(buffer)
-	if err != nil {
-		return 0, nil, err
-	}
-	return n, addr, nil
+	return c.conn.ReadFromUDP(buffer)
 }
 
 func (c *connConnection) setDeadline(deadline time.Duration) error {
-	err := c.conn.SetReadDeadline(time.Now().Add(deadline))
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.conn.SetReadDeadline(time.Now().Add(deadline))
 }
 
 func (c *connConnection) close() {


### PR DESCRIPTION
### Overview
There's a few commits in this pull request, brief overview:
- Add support for variable blocksize in single port mode
- Fix race in hook tests
- Add counters for sent and received datagrams
- Cleanup connection.go a little

I'm aware generally there should be one change/feature per pull request but these are small changes. I can split the commits into seperate PRs if needed.

### Add support for variable blocksize in single port mode
This allows you to set an upper bound on blocksize accepted in the server. We cannot arbitrary support any size (like in the regular mode) but this is a good compromise as most clients don't really use values >2000 anyway.

### Fix race in hook tests
Using `defer s.Shutdown()` was causing issues in the tests causing them to occasionally race. Here we just change to explicitly call `s.Shutdown()` .

### Add counters for sent and received datagrams
Instead of just a generic 'total blocks' actually count sent and received, this is useful for debugging transfers.

### Test plan:
Created a simple [test program](https://pastebin.com/VnS3CCUL).
Ran:
```
busybox tftp -g -r /tmp/testfile -b 2000 localhost
/tmp/testfile        100% |***************************| 60480  0:00:00 ETA
```
Output:
```
$ sudo ./main

2019/12/23 11:32:17 %v {::1 /tmp/testfile 59843 false octet map[blksize:2000 tsize:60480] 4.884614ms 32 32}
60480 bytes sent
```