### PR TITLE
Close several races found by the race detector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
-
+go:
+  - '1.13'
 os:
   - linux
   - osx
-
 before_install:
   - ulimit -n 4096
+script:
+  - go test -v -race

--- a/single_port.go
+++ b/single_port.go
@@ -5,68 +5,43 @@ import (
 )
 
 func (s *Server) singlePortProcessRequests() error {
-	var (
-		localAddr  net.IP
-		cnt, maxSz int
-		srcAddr    net.Addr
-		err        error
-		buf        []byte
-	)
-	defer func() {
-		if r := recover(); r != nil {
-			// We've received a new connection on the same IP+Port tuple
-			// as a previous connection before garbage collection has occured
-			s.handlers[srcAddr.String()] = make(chan []byte, 1)
-			go func(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int, listener chan []byte) {
-				err := s.handlePacket(localAddr, remoteAddr, buffer, n, maxBlockLen, listener)
-				if err != nil && s.hook != nil {
-					s.hook.OnFailure(TransferStats{
-						SenderAnticipateEnabled: s.sendAEnable,
-					}, err)
-				}
-
-			}(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, s.handlers[srcAddr.String()])
-			s.singlePortProcessRequests()
-		}
-	}()
 	for {
 		select {
-		case q := <-s.quit:
-			q <- struct{}{}
+		case <-s.cancel.Done():
+			s.wg.Wait()
 			return nil
-		case handlersToFree := <-s.runGC:
-			for _, handler := range handlersToFree {
-				delete(s.handlers, handler)
-			}
 		default:
-			buf = s.bufPool.Get().([]byte)
-			cnt, localAddr, srcAddr, maxSz, err = s.getPacket(buf)
+			buf := make([]byte, s.maxBlockLen+4)
+			cnt, localAddr, srcAddr, maxSz, err := s.getPacket(buf)
 			if err != nil || cnt == 0 {
-				if s.hook != nil {
-					s.hook.OnFailure(TransferStats{
-						SenderAnticipateEnabled: s.sendAEnable,
-					}, err)
-				}
-				s.bufPool.Put(buf)
+				s.Hook().OnFailure(TransferStats{
+					SenderAnticipateEnabled: s.sendAEnable,
+				}, err)
 				continue
 			}
-			if receiverChannel, ok := s.handlers[srcAddr.String()]; ok {
-				select {
-				case receiverChannel <- buf[:cnt]:
-				default:
-					// We don't want to block the main loop if a channel is full
-				}
-			} else {
-				s.handlers[srcAddr.String()] = make(chan []byte, 1)
-				go func(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int, listener chan []byte) {
-					err := s.handlePacket(localAddr, remoteAddr, buffer, n, maxBlockLen, listener)
-					if err != nil && s.hook != nil {
-						s.hook.OnFailure(TransferStats{
+			s.Lock()
+			receiverChannel, ok := s.handlers[srcAddr.String()]
+			if !ok {
+				// New connection, create a handler
+				lc := make(chan []byte, 1)
+				s.handlers[srcAddr.String()] = lc
+				s.Unlock()
+				go func() {
+					err := s.handlePacket(localAddr, srcAddr, buf, cnt, maxSz, lc)
+					if err != nil {
+						s.Hook().OnFailure(TransferStats{
 							SenderAnticipateEnabled: s.sendAEnable,
 						}, err)
 					}
-
-				}(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, s.handlers[srcAddr.String()])
+				}()
+				continue
+			}
+			s.Unlock()
+			// Existing connection, hand this packet over.
+			select {
+			case receiverChannel <- buf[:cnt]:
+			default:
+				// We don't want to block the main loop if a channel is full
 			}
 		}
 	}
@@ -109,21 +84,5 @@ func (s *Server) getPacket(buf []byte) (int, net.IP, *net.UDPAddr, int, error) {
 			return 0, nil, nil, 0, err
 		}
 		return cnt, nil, srcAddr.(*net.UDPAddr), blockLength, nil
-	}
-}
-
-// internalGC collects all the finished signals from each connection's goroutine
-// The main loop is sent the key to be nil'ed after the gcInterval has passed
-func (s *Server) internalGC() {
-	var completedHandlers []string
-	for {
-		select {
-		case newHandler := <-s.gcCollect:
-			completedHandlers = append(completedHandlers, newHandler)
-			if len(completedHandlers) > s.gcThreshold {
-				s.runGC <- completedHandlers
-				completedHandlers = nil
-			}
-		}
 	}
 }

--- a/tftp_anticipate_test.go
+++ b/tftp_anticipate_test.go
@@ -28,8 +28,9 @@ func makeTestServerAnticipateWindow() (*Server, *Client) {
 	if err != nil {
 		panic(err)
 	}
+	s.SetConn(conn)
 
-	go s.Serve(conn)
+	go s.Start()
 
 	// Create client for that server
 	c, err := NewClient(localSystem(conn))


### PR DESCRIPTION
* Give Server a Mutex to lock accessed fields as they are written and
  read.  THis is mostly to make tests happy, but also covers what is
  needed of someone is altering timeouts, etc. on a running Server.

* Change the Shutdown() routine to use Context-based cancellation.
  This avoids a couple of initialization order based races, and gets
  rid of the need to pass channels of channels around.

* Split Serve() into SetConn() and Start().  This makes the race
  detector happy by not needing to pass a conn into a goroutine
  directly. The race detector was being triggered by the sequence of
  go svr.Serve(conn); defer s.Shutdown()

* Get rid of handler GC stuff in favor of immediate handler cleanup
  under a mutex.  This gets rid of the confusing recover based retry
  logic for handling the case where GC has not happened yet is no
  longer needed, since you don't need additional GC logic if you don't
  leak garbage in the first place.  That there is no longer a chance
  for stack exhaustion vis recursive calls to the parent function in
  the recover path is just an added bonus.