### PR TITLE
Variable block size logic does not work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mtniehaus/tftp
+module github.com/mtniehaus/tftp/v2
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pin/tftp
+module github.com/mtniehaus/tftp
 
 go 1.13
 

--- a/sender.go
+++ b/sender.go
@@ -178,6 +178,7 @@ func (s *sender) setBlockSize(blksize string) error {
 	if n > 65464 {
 		return fmt.Errorf("blksize too large: %d", n)
 	}
+	fmt.Printf("s.maxBlockLen = %d  n = %d", s.maxBlockLen, n)
 	if s.maxBlockLen > 0 && n > s.maxBlockLen {
 		n = s.maxBlockLen
 		s.opts["blksize"] = strconv.Itoa(n)

--- a/sender.go
+++ b/sender.go
@@ -178,7 +178,6 @@ func (s *sender) setBlockSize(blksize string) error {
 	if n > 65464 {
 		return fmt.Errorf("blksize too large: %d", n)
 	}
-	fmt.Printf("s.maxBlockLen = %d  n = %d", s.maxBlockLen, n)
 	if s.maxBlockLen > 0 && n > s.maxBlockLen {
 		n = s.maxBlockLen
 		s.opts["blksize"] = strconv.Itoa(n)


### PR DESCRIPTION
When using the latest code from /pin/tftp, the block size used for tftp transfers (at least on a Windows Server 2016 OS) would always be negotiated by the go logic to 512 bytes, even when the client would indicate that it supports larger block sizes.

The logic was modified to use the largest possible block size, either as configured by callers to the go routines, or as limited by the client options specified to the service.