### PR TITLE
Upgrade to v2 in Go's way

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Partially implements (tsize server side only):
 Set of features is sufficient for PXE boot support.
 
 ``` go
-import "github.com/pin/tftp"
+import "github.com/pin/tftp/v2"
 ```
 
 The package is cohesive to Golang `io`. Particularly it implements

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pin/tftp
+module github.com/pin/tftp/v2
 
 go 1.13
 

--- a/receiver.go
+++ b/receiver.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/netascii"
+	"github.com/pin/tftp/v2/netascii"
 )
 
 // IncomingTransfer provides methods that expose information associated with

--- a/sender.go
+++ b/sender.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/netascii"
+	"github.com/pin/tftp/v2/netascii"
 )
 
 // OutgoingTransfer provides methods to set the outgoing transfer size and


### PR DESCRIPTION
Go require use `/v2` in `go.mod` to identify version 2. Otherwise user will got a incompatible warning.
More info, please see: 
- https://go.dev/blog/migrating-to-go-modules
- https://stackoverflow.com/questions/57355929/what-does-incompatible-in-go-mod-mean-will-it-cause-harm

And after pull request is merged, you should make a new tag, such as `v2.3.0` to release this change.