### PR TITLE
Ctx-based cancellation in Shutdown(), better single port handler cleanup

### DIFF
--- a/single_port.go
+++ b/single_port.go
@@ -5,49 +5,20 @@ import (
 )
 
 func (s *Server) singlePortProcessRequests() error {
-	var (
-		localAddr  net.IP
-		cnt, maxSz int
-		srcAddr    net.Addr
-		err        error
-		buf        []byte
-	)
-	defer func() {
-		if r := recover(); r != nil {
-			// We've received a new connection on the same IP+Port tuple
-			// as a previous connection before garbage collection has occured
-			s.handlers[srcAddr.String()] = make(chan []byte, 1)
-			go func(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int, listener chan []byte) {
-				err := s.handlePacket(localAddr, remoteAddr, buffer, n, maxBlockLen, listener)
-				if err != nil && s.hook != nil {
-					s.hook.OnFailure(TransferStats{
-						SenderAnticipateEnabled: s.sendAEnable,
-					}, err)
-				}
-
-			}(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, s.handlers[srcAddr.String()])
-			s.singlePortProcessRequests()
-		}
-	}()
 	for {
 		select {
-		case q := <-s.quit:
-			q <- struct{}{}
+		case <-s.cancel.Done():
+			s.wg.Wait()
 			return nil
-		case handlersToFree := <-s.runGC:
-			for _, handler := range handlersToFree {
-				delete(s.handlers, handler)
-			}
 		default:
-			buf = s.bufPool.Get().([]byte)
-			cnt, localAddr, srcAddr, maxSz, err = s.getPacket(buf)
+			buf := make([]byte, s.maxBlockLen+4)
+			cnt, localAddr, srcAddr, maxSz, err := s.getPacket(buf)
 			if err != nil || cnt == 0 {
 				if s.hook != nil {
 					s.hook.OnFailure(TransferStats{
 						SenderAnticipateEnabled: s.sendAEnable,
 					}, err)
 				}
-				s.bufPool.Put(buf)
 				continue
 			}
 			if receiverChannel, ok := s.handlers[srcAddr.String()]; ok {
@@ -57,16 +28,17 @@ func (s *Server) singlePortProcessRequests() error {
 					// We don't want to block the main loop if a channel is full
 				}
 			} else {
-				s.handlers[srcAddr.String()] = make(chan []byte, 1)
-				go func(localAddr net.IP, remoteAddr *net.UDPAddr, buffer []byte, n, maxBlockLen int, listener chan []byte) {
-					err := s.handlePacket(localAddr, remoteAddr, buffer, n, maxBlockLen, listener)
+				lc := make(chan []byte, 1)
+				s.handlers[srcAddr.String()] = lc
+				go func() {
+					err := s.handlePacket(localAddr, srcAddr, buf, cnt, maxSz, lc)
 					if err != nil && s.hook != nil {
 						s.hook.OnFailure(TransferStats{
 							SenderAnticipateEnabled: s.sendAEnable,
 						}, err)
 					}
 
-				}(localAddr, srcAddr.(*net.UDPAddr), buf, cnt, maxSz, s.handlers[srcAddr.String()])
+				}()
 			}
 		}
 	}
@@ -109,21 +81,5 @@ func (s *Server) getPacket(buf []byte) (int, net.IP, *net.UDPAddr, int, error) {
 			return 0, nil, nil, 0, err
 		}
 		return cnt, nil, srcAddr.(*net.UDPAddr), blockLength, nil
-	}
-}
-
-// internalGC collects all the finished signals from each connection's goroutine
-// The main loop is sent the key to be nil'ed after the gcInterval has passed
-func (s *Server) internalGC() {
-	var completedHandlers []string
-	for {
-		select {
-		case newHandler := <-s.gcCollect:
-			completedHandlers = append(completedHandlers, newHandler)
-			if len(completedHandlers) > s.gcThreshold {
-				s.runGC <- completedHandlers
-				completedHandlers = nil
-			}
-		}
 	}
 }

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -427,7 +427,6 @@ func makeTestServer(singlePort bool) (*Server, *Client) {
 
 	if singlePort {
 		s.SetBlockSize(2000)
-		s.gcThreshold = 100000
 		s.EnableSinglePort()
 	}
 


### PR DESCRIPTION
This is a part of #59 originally developed by @VictorLowther

Original description from #59:

* Change the Shutdown() routine to use Context-based cancellation.
This avoids a couple of initialization order based races, and gets
rid of the need to pass channels of channels around.

* Get rid of handler GC stuff in favor of immediate handler cleanup
under a mutex. This gets rid of the confusing recover based retry
logic for handling the case where GC has not happened yet is no
longer needed, since you don't need additional GC logic if you don't
leak garbage in the first place. That there is no longer a chance
for stack exhaustion vis recursive calls to the parent function in
the recover path is just an added bonus.

NB: This is only a part of original #59, another commit on top of this one is required to get rid of the race conditions.