### PR TITLE
Revert "Upgrade to v2 in Go's way"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Partially implements (tsize server side only):
 Set of features is sufficient for PXE boot support.
 
 ``` go
-import "github.com/pin/tftp/v2"
+import "github.com/pin/tftp"
 ```
 
 The package is cohesive to Golang `io`. Particularly it implements

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pin/tftp/v2
+module github.com/pin/tftp
 
 go 1.13
 

--- a/receiver.go
+++ b/receiver.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/v2/netascii"
+	"github.com/pin/tftp/netascii"
 )
 
 // IncomingTransfer provides methods that expose information associated with

--- a/sender.go
+++ b/sender.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/v2/netascii"
+	"github.com/pin/tftp/netascii"
 )
 
 // OutgoingTransfer provides methods to set the outgoing transfer size and


### PR DESCRIPTION
Reverts pin/tftp#67

We discussed that in #70: going to make v2 incompatible again. We will cut v3 to make the code fully compatible with go modules.

https://go.dev/ref/mod#major-version-suffixes

    Many Go projects released versions at v2 or higher without using a major version suffix before migrating to modules (perhaps before modules were even introduced). These versions are annotated with a +incompatible build tag (for example, v2.0.0+incompatible).