### PR TITLE
Fix the most annoying race in single port case

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -80,6 +80,8 @@ func (c *chanConnection) setDeadline(deadline time.Duration) error {
 }
 
 func (c *chanConnection) close() {
+	c.server.Lock()
+	defer c.server.Unlock()
 	close(c.channel)
 	delete(c.server.handlers, c.addr.String())
 }

--- a/single_port.go
+++ b/single_port.go
@@ -21,7 +21,9 @@ func (s *Server) singlePortProcessRequests() error {
 				}
 				continue
 			}
+			s.Lock()
 			if receiverChannel, ok := s.handlers[srcAddr.String()]; ok {
+				s.Unlock()
 				select {
 				case receiverChannel <- buf[:cnt]:
 				default:
@@ -30,6 +32,7 @@ func (s *Server) singlePortProcessRequests() error {
 			} else {
 				lc := make(chan []byte, 1)
 				s.handlers[srcAddr.String()] = lc
+				s.Unlock()
 				go func() {
 					err := s.handlePacket(localAddr, srcAddr, buf, cnt, maxSz, lc)
 					if err != nil && s.hook != nil {


### PR DESCRIPTION
This is part of the #59 originally developed by @VictorLowther


We are manipulating handlers map used in single-port mode. It needs to be synchronous. Still not makes race-detector happy so far. Because not all fixes from #59 applied yet.