### PR TITLE
fix mutex visibility

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -45,8 +45,8 @@ type chanConnection struct {
 
 func (c *chanConnection) sendTo(data []byte, addr *net.UDPAddr) error {
 	var err error
-	c.server.Lock()
-	defer c.server.Unlock()
+	c.server.mu.Lock()
+	defer c.server.mu.Unlock()
 	if conn, ok := c.server.conn.(*net.UDPConn); ok {
 		srcAddr := c.srcAddr.IP.To4()
 		var cmm []byte
@@ -82,8 +82,8 @@ func (c *chanConnection) setDeadline(deadline time.Duration) error {
 }
 
 func (c *chanConnection) close() {
-	c.server.Lock()
-	defer c.server.Unlock()
+	c.server.mu.Lock()
+	defer c.server.mu.Unlock()
 	close(c.channel)
 	delete(c.server.handlers, c.addr.String())
 }

--- a/single_port.go
+++ b/single_port.go
@@ -21,9 +21,9 @@ func (s *Server) singlePortProcessRequests() error {
 				}
 				continue
 			}
-			s.Lock()
+			s.mu.Lock()
 			if receiverChannel, ok := s.handlers[srcAddr.String()]; ok {
-				s.Unlock()
+				s.mu.Unlock()
 				select {
 				case receiverChannel <- buf[:cnt]:
 				default:
@@ -32,7 +32,7 @@ func (s *Server) singlePortProcessRequests() error {
 			} else {
 				lc := make(chan []byte, 1)
 				s.handlers[srcAddr.String()] = lc
-				s.Unlock()
+				s.mu.Unlock()
 				go func() {
 					err := s.handlePacket(localAddr, srcAddr, buf, cnt, maxSz, lc)
 					if err != nil && s.hook != nil {

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -557,14 +557,14 @@ func serverTimeoutSendTest(s *Server, c *Client, t *testing.T) {
 	s.SetTimeout(time.Second)
 	s.SetRetries(2)
 	sec := make(chan error, 1)
-	s.Lock()
+	s.mu.Lock()
 	s.readHandler = func(filename string, rf io.ReaderFrom) error {
 		r := io.LimitReader(newRandReader(rand.NewSource(42)), 80000)
 		_, err := rf.ReadFrom(r)
 		sec <- err
 		return err
 	}
-	s.Unlock()
+	s.mu.Unlock()
 	defer s.Shutdown()
 	filename := "test-server-send-timeout"
 	mode := "octet"
@@ -597,14 +597,14 @@ func serverReceiveTimeoutTest(s *Server, c *Client, t *testing.T) {
 	s.SetTimeout(time.Second)
 	s.SetRetries(2)
 	sec := make(chan error, 1)
-	s.Lock()
+	s.mu.Lock()
 	s.writeHandler = func(filename string, wt io.WriterTo) error {
 		buf := &bytes.Buffer{}
 		_, err := wt.WriteTo(buf)
 		sec <- err
 		return err
 	}
-	s.Unlock()
+	s.mu.Unlock()
 	defer s.Shutdown()
 	filename := "test-server-receive-timeout"
 	mode := "octet"
@@ -637,7 +637,7 @@ func TestClientReceiveTimeout(t *testing.T) {
 	s, c := makeTestServer(false)
 	c.SetTimeout(time.Second)
 	c.SetRetries(2)
-	s.Lock()
+	s.mu.Lock()
 	s.readHandler = func(filename string, rf io.ReaderFrom) error {
 		r := &slowReader{
 			r:     io.LimitReader(newRandReader(rand.NewSource(42)), 80000),
@@ -647,7 +647,7 @@ func TestClientReceiveTimeout(t *testing.T) {
 		_, err := rf.ReadFrom(r)
 		return err
 	}
-	s.Unlock()
+	s.mu.Unlock()
 	defer s.Shutdown()
 	filename := "test-client-receive-timeout"
 	mode := "octet"
@@ -670,7 +670,7 @@ func TestClientSendTimeout(t *testing.T) {
 	s, c := makeTestServer(false)
 	c.SetTimeout(time.Second)
 	c.SetRetries(2)
-	s.Lock()
+	s.mu.Lock()
 	s.writeHandler = func(filename string, wt io.WriterTo) error {
 		w := &slowWriter{
 			n:     3,
@@ -679,7 +679,7 @@ func TestClientSendTimeout(t *testing.T) {
 		_, err := wt.WriteTo(w)
 		return err
 	}
-	s.Unlock()
+	s.mu.Unlock()
 	defer s.Shutdown()
 	filename := "test-client-send-timeout"
 	mode := "octet"


### PR DESCRIPTION
Hello. I think Lock/Unlock mutex methods should not be user accessible. This is not a good practice. Users of your package may accidentally lock the mutex. The essence of the fix is to hide the mutex from the user.
Best regards.