### PR TITLE
Replace deprecated ioutil package

### DIFF
--- a/netascii/netascii_test.go
+++ b/netascii/netascii_test.go
@@ -2,7 +2,7 @@ package netascii
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -20,7 +20,7 @@ var basic = map[string]string{
 func TestTo(t *testing.T) {
 	for text, netascii := range basic {
 		to := ToReader(strings.NewReader(text))
-		n, _ := ioutil.ReadAll(to)
+		n, _ := io.ReadAll(to)
 		if !bytes.Equal(n, []byte(netascii)) {
 			t.Errorf("%q to netascii: %q != %q", text, n, netascii)
 		}
@@ -33,7 +33,7 @@ func TestFrom(t *testing.T) {
 		b := &bytes.Buffer{}
 		from := FromWriter(b)
 		r.WriteTo(from)
-		n, _ := ioutil.ReadAll(b)
+		n, _ := io.ReadAll(b)
 		if string(n) != text {
 			t.Errorf("%q from netascii: %q != %q", netascii, n, text)
 		}
@@ -69,7 +69,7 @@ func TestWriteRead(t *testing.T) {
 	two := &bytes.Buffer{}
 	from := FromWriter(two)
 	one.WriteTo(from)
-	text2, _ := ioutil.ReadAll(two)
+	text2, _ := io.ReadAll(two)
 	if text != string(text2) {
 		t.Errorf("text mismatch \n%x \n%x", text, text2)
 	}
@@ -82,7 +82,7 @@ func TestOneByte(t *testing.T) {
 	two := &bytes.Buffer{}
 	from := FromWriter(two)
 	one.WriteTo(from)
-	text2, _ := ioutil.ReadAll(two)
+	text2, _ := io.ReadAll(two)
 	if text != string(text2) {
 		t.Errorf("text mismatch \n%x \n%x", text, text2)
 	}

--- a/tftp_test.go
+++ b/tftp_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -289,7 +288,7 @@ func TestByOneByte(t *testing.T) {
 	if n != length {
 		t.Errorf("%s read length mismatch: %d != %d", filename, n, length)
 	}
-	bs, _ := ioutil.ReadAll(io.LimitReader(
+	bs, _ := io.ReadAll(io.LimitReader(
 		newRandReader(rand.NewSource(42)), length))
 	if !bytes.Equal(bs, buf.Bytes()) {
 		t.Errorf("\nsent: %x\nrcvd: %x", bs, buf)
@@ -365,7 +364,7 @@ func testSendReceive(t *testing.T, client *Client, length int64) {
 	if n != length {
 		t.Errorf("%s read length mismatch: %d != %d", filename, n, length)
 	}
-	bs, _ := ioutil.ReadAll(io.LimitReader(
+	bs, _ := io.ReadAll(io.LimitReader(
 		newRandReader(rand.NewSource(42)), length))
 	if !bytes.Equal(bs, buf.Bytes()) {
 		t.Errorf("\nsent: %x\nrcvd: %x", bs, buf)
@@ -410,7 +409,7 @@ func TestSendTsizeFromSeek(t *testing.T) {
 		t.Errorf("size expected: 100, got %d", size)
 	}
 
-	r.WriteTo(ioutil.Discard)
+	r.WriteTo(io.Discard)
 
 	c.RequestTSize(false)
 	r, _ = c.Receive("f", "octet")
@@ -421,7 +420,7 @@ func TestSendTsizeFromSeek(t *testing.T) {
 		}
 	}
 
-	r.WriteTo(ioutil.Discard)
+	r.WriteTo(io.Discard)
 }
 
 type testBackend struct {
@@ -767,7 +766,7 @@ func TestRequestPacketInfo(t *testing.T) {
 				localIP = net.IP{}
 			}
 			localIPMu.Unlock()
-			_, err := wt.WriteTo(ioutil.Discard)
+			_, err := wt.WriteTo(io.Discard)
 			if err != nil {
 				t.Logf("receiving from client: %v", err)
 			}
@@ -842,7 +841,7 @@ func TestRequestPacketInfo(t *testing.T) {
 			t.Logf("start receiving from %v: %v", ip, err)
 			continue
 		}
-		_, err = it.WriteTo(ioutil.Discard)
+		_, err = it.WriteTo(io.Discard)
 		if err != nil {
 			t.Logf("receiving from %v: %v", ip, err)
 			continue


### PR DESCRIPTION
See https://pkg.go.dev/io/ioutil

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code.