### PR TITLE
Adding support for client side to choose required source ip address

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,10 +22,13 @@ func NewClient(addr string) (*Client, error) {
 	}, nil
 }
 
-// NewClient creates TFTP client for server on address provided.
-func NewClientWithLocalAddr(addr string, laddr string) (*Client, error) {
-	if laddr == "" {
-		return nil, fmt.Errorf("local addr is empty")
+// NewClientWithLocalAddr creates TFTP client for server on local ip address laddr provided.
+func NewClientWithLocalAddr(addr string, localaddr string) (*Client, error) {
+	if localaddr == "" {
+		return nil, fmt.Errorf("localaddr is empty")
+	}
+	if net.ParseIP(localaddr) == nil {
+		return nil, fmt.Errorf("provided localaddr: %s is not valid ip addr", localaddr)
 	}
 	a, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
@@ -36,7 +39,7 @@ func NewClientWithLocalAddr(addr string, laddr string) (*Client, error) {
 		timeout: defaultTimeout,
 		retries: defaultRetries,
 		localAddr: &net.UDPAddr{
-			IP:   net.ParseIP(laddr),
+			IP:   net.ParseIP(localaddr),
 			Port: 0,
 		},
 	}, nil


### PR DESCRIPTION
Opening pull request to support new client type, `func NewClientWithLocalAddr(addr string, localaddr string) (*Client, error)`,

- This client type will required addr remote address as per current flow only
- localaddr will be string of IPv4 or IPv6 from available source IP address, if given input is empty or not valid IP addr then return error

This will essentially help to pass traffic with specific source IP if multiple interfaces are present on system.

